### PR TITLE
Big Sur fix

### DIFF
--- a/BGMDriver/BGMDriver/BGM_Device.cpp
+++ b/BGMDriver/BGMDriver/BGM_Device.cpp
@@ -1206,6 +1206,7 @@ void	BGM_Device::StartIO(UInt32 inClientID)
     // frames or increase latency.
     if(!clientIsBGMApp && bgmAppHasClientRegistered)
     {
+        DebugMsg("BGM_Device::StartIO: StartBGMAppPlayThroughSync.");
         UInt64 theXPCError = StartBGMAppPlayThroughSync(GetObjectID() == kObjectID_Device_UI_Sounds);
         
         switch(theXPCError)
@@ -1217,9 +1218,15 @@ void	BGM_Device::StartIO(UInt32 inClientID)
             case kBGMXPC_MessageFailure:
                 // This most likely means BGMXPCHelper isn't installed or has crashed. IO will probably still work,
                 // but we may drop frames while the audio hardware starts up.
-                LogError("BGM_Device::StartIO: Couldn't reach BGMApp via XPC. Attempting to start IO anyway.");
+                LogWarning("BGM_Device::StartIO: Couldn't reach BGMApp via XPC. Attempting to start IO anyway.");
                 break;
-                
+                       
+           case kBGMXPC_Timeout:
+               // XPC timeout. IO will probably still work,
+               // but we may drop frames while the audio hardware starts up.
+               LogWarning("BGM_Device::StartIO: Couldn't reach BGMApp via XPC (timeout). Attempting to start IO anyway.");
+               break;
+
             case kBGMXPC_ReturningEarlyError:
                 // This can (and might always) happen when the user changes output device in BGMApp while IO is running.
                 // See BGMAudioDeviceManager::startPlayThroughSync and BGMPlayThrough::WaitForOutputDeviceToStart.
@@ -1227,8 +1234,9 @@ void	BGM_Device::StartIO(UInt32 inClientID)
                 break;
                 
             default:
+                DebugMsg("BGM_Device::StartIO: BGMApp failed to start the output device. theXPCError=%llu", theXPCError);
                 LogError("BGM_Device::StartIO: BGMApp failed to start the output device. theXPCError=%llu", theXPCError);
-                Throw(CAException(kAudioHardwareNotRunningError));
+                //Throw(CAException(kAudioHardwareNotRunningError));
         }
     }
 }

--- a/BGMDriver/BGMDriver/BGM_XPCHelper.m
+++ b/BGMDriver/BGMDriver/BGM_XPCHelper.m
@@ -35,7 +35,7 @@
 
 #pragma clang assume_nonnull begin
 
-static const UInt64 REMOTE_CALL_DEFAULT_TIMEOUT_SECS = 30;
+static const UInt64 REMOTE_CALL_DEFAULT_TIMEOUT_SECS = 1;
 
 static NSXPCConnection* CreateXPCHelperConnection()
 {


### PR DESCRIPTION
@kyleneideck 
There is issue in XPC in Big Sur: XPC request are coming to BGMApp, but driver doesn't get response and got xpc timeout.
There is temporary fix for Big Sur: decreased timeout and catch kBGMXPC_Timeout result.