### PR TITLE
updates brew cask instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ BackgroundMusic-0.3.2.pkg</a> (571 KB)
 Install using [Homebrew](https://brew.sh/) by running the following command in **Terminal**:
 
 ```bash
-brew cask install background-music
+brew install --cask background-music
 ```
 
 If you want the snapshot version, run:


### PR DESCRIPTION
`brew cask install` appears to be deprecated, and using it gets this warning:

`Warning: Calling brew cask install is deprecated! Use brew install
[--cask] instead.`

So this is a super small change in README to reflect that.

I guess one could just omit the `--cask` even, too and it'd still work? 