### PR TITLE
Update README.md for option 2 snapshot version regarding homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you want the snapshot version, run:
 
 ```bash
 brew tap homebrew/cask-versions
-brew cask install background-music-pre
+brew install --cask background-music-pre
 ```
 
 # Installing from Source Code


### PR DESCRIPTION
I upgraded to big sur today and had to use the snapshot version of background music and noticed a slight error in the README.

`brew cask` is deprecated and i've updated the snapshot version of downloading it in option 2 with homebrew with the correct command of `brew install --cask`.

Apologies if there's any errors regarding the PR process since this is the first time i'm contributing to a relatively large repository! 