### PR TITLE
Apple script additions

### DIFF
--- a/BGMApp/BGMApp.xcodeproj/project.pbxproj
+++ b/BGMApp/BGMApp.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		27FB8C301DE4758A0084DB9D /* BGMPlayThrough.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C1962E51BC94E91008A4DF7 /* BGMPlayThrough.cpp */; };
 		27FB8C311DE4758A0084DB9D /* BGM_Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27FB8C2E1DE468320084DB9D /* BGM_Utils.cpp */; };
 		9E129A412602AE620005851B /* BGMASApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E129A402602AE620005851B /* BGMASApplication.m */; };
+		9E542C7026057FBA0016C0B5 /* BGMASApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E129A402602AE620005851B /* BGMASApplication.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1224,6 +1225,7 @@
 				1CD989361ECFFC9E0014BBBF /* CACFDictionary.cpp in Sources */,
 				1CD989371ECFFC9E0014BBBF /* CACFNumber.cpp in Sources */,
 				1CD989381ECFFC9E0014BBBF /* CACFString.cpp in Sources */,
+				9E542C7026057FBA0016C0B5 /* BGMASApplication.m in Sources */,
 				1CD989391ECFFC9E0014BBBF /* CADebugger.cpp in Sources */,
 				1CD9893A1ECFFC9E0014BBBF /* CADebugMacros.cpp in Sources */,
 				1CD9893B1ECFFC9E0014BBBF /* CADebugPrintf.cpp in Sources */,

--- a/BGMApp/BGMApp.xcodeproj/project.pbxproj
+++ b/BGMApp/BGMApp.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 		27FB8C2F1DE468320084DB9D /* BGM_Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27FB8C2E1DE468320084DB9D /* BGM_Utils.cpp */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGM_Utils.cpp"; }; };
 		27FB8C301DE4758A0084DB9D /* BGMPlayThrough.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C1962E51BC94E91008A4DF7 /* BGMPlayThrough.cpp */; };
 		27FB8C311DE4758A0084DB9D /* BGM_Utils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27FB8C2E1DE468320084DB9D /* BGM_Utils.cpp */; };
+		9E129A412602AE620005851B /* BGMASApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E129A402602AE620005851B /* BGMASApplication.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -433,6 +434,8 @@
 		27F7D48F1D2483B100821C4B /* BGMDecibel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BGMDecibel.m; path = "Music Players/BGMDecibel.m"; sourceTree = "<group>"; };
 		27F7D4911D2484A300821C4B /* Decibel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Decibel.h; path = "Music Players/Decibel.h"; sourceTree = "<group>"; };
 		27FB8C2E1DE468320084DB9D /* BGM_Utils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BGM_Utils.cpp; path = ../SharedSource/BGM_Utils.cpp; sourceTree = "<group>"; };
+		9E129A3F2602AE620005851B /* BGMASApplication.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BGMASApplication.h; path = Scripting/BGMASApplication.h; sourceTree = "<group>"; };
+		9E129A402602AE620005851B /* BGMASApplication.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BGMASApplication.m; path = Scripting/BGMASApplication.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -562,6 +565,8 @@
 				1C2FC31D1EC723A100A76592 /* BGMASOutputDevice.h */,
 				1C2FC31A1EC7238A00A76592 /* BGMASOutputDevice.mm */,
 				1C2FC2FF1EB4D6E700A76592 /* BGMApp.sdef */,
+				9E129A3F2602AE620005851B /* BGMASApplication.h */,
+				9E129A402602AE620005851B /* BGMASApplication.m */,
 			);
 			name = Scripting;
 			sourceTree = "<group>";
@@ -1152,6 +1157,7 @@
 				1C837DD81F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm in Sources */,
 				1C9258472090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.m in Sources */,
 				1C1963011BCAC0F6008A4DF7 /* CACFString.cpp in Sources */,
+				9E129A412602AE620005851B /* BGMASApplication.m in Sources */,
 				1C1962E71BC94E91008A4DF7 /* BGMPlayThrough.cpp in Sources */,
 				1C8D8304204238DB00A838F2 /* BGMSwinsian.m in Sources */,
 				1C1962FA1BCAC061008A4DF7 /* CADebugMacros.cpp in Sources */,

--- a/BGMApp/BGMApp/BGMAppDelegate.h
+++ b/BGMApp/BGMApp/BGMAppDelegate.h
@@ -24,6 +24,7 @@
 
 // Local Includes
 #import "BGMAudioDeviceManager.h"
+#import "BGMAppVolumesController.h"
 
 // System Includes
 #import <Cocoa/Cocoa.h>
@@ -53,6 +54,7 @@ static NSInteger const kSeparatorBelowVolumesMenuItemTag = 4;
 @property (weak) IBOutlet NSMenuItem* debugLoggingMenuItemUnwrapped;
 
 @property (readonly) BGMAudioDeviceManager* audioDevices;
+@property BGMAppVolumesController* appVolumes;
 
 @end
 

--- a/BGMApp/BGMApp/BGMAppDelegate.mm
+++ b/BGMApp/BGMApp/BGMAppDelegate.mm
@@ -64,7 +64,6 @@ static NSString* const kOptShowDockIcon      = @"--show-dock-icon";
     BGMAutoPauseMenuItem* autoPauseMenuItem;
     BGMMusicPlayers* musicPlayers;
     BGMSystemSoundsVolume* systemSoundsVolume;
-    BGMAppVolumesController* appVolumes;
     BGMOutputDeviceMenuSection* outputDeviceMenuSection;
     BGMPreferencesMenu* prefsMenu;
     BGMDebugLoggingMenuItem* debugLoggingMenuItem;
@@ -73,6 +72,7 @@ static NSString* const kOptShowDockIcon      = @"--show-dock-icon";
 }
 
 @synthesize audioDevices = audioDevices;
+@synthesize appVolumes = appVolumes;
 
 - (void) awakeFromNib {
     [super awakeFromNib];

--- a/BGMApp/BGMApp/BGMAppVolumes.h
+++ b/BGMApp/BGMApp/BGMAppVolumes.h
@@ -44,6 +44,9 @@
 
 - (void) removeAllAppVolumeMenuItems;
 
+- (BGMAppVolumeAndPan) getVolumeAndPanForApp:(NSRunningApplication*)app;
+- (void) setVolumeAndPan:(BGMAppVolumeAndPan)volumeAndPan forApp:(NSRunningApplication*)app;
+
 @end
 
 // Protocol for the UI custom classes

--- a/BGMApp/BGMApp/BGMAppVolumes.m
+++ b/BGMApp/BGMApp/BGMAppVolumes.m
@@ -189,7 +189,7 @@ static NSString* const kMoreAppsMenuTitle          = @"More Apps";
             [(BGMAVM_VolumeSlider*)subview setRelativeVolume:volumeAndPan.volume];
         }
 
-        // Get the pan position.
+        // Set the pan position.
         if (volumeAndPan.pan != -1 && [subview isKindOfClass:[BGMAVM_PanSlider class]]) {
             [(BGMAVM_PanSlider*)subview setPanPosition:volumeAndPan.pan];
         }

--- a/BGMApp/BGMApp/BGMAppVolumes.m
+++ b/BGMApp/BGMApp/BGMAppVolumes.m
@@ -184,7 +184,7 @@ static NSString* const kMoreAppsMenuTitle          = @"More Apps";
     }
 
     for (NSView* subview in item.view.subviews) {
-        // Get the volume.
+        // Set the volume.
         if (volumeAndPan.volume != -1 && [subview isKindOfClass:[BGMAVM_VolumeSlider class]]) {
             [(BGMAVM_VolumeSlider*)subview setRelativeVolume:volumeAndPan.volume];
         }
@@ -520,4 +520,3 @@ static NSString* const kMoreAppsMenuTitle          = @"More Apps";
 }
 
 @end
-

--- a/BGMApp/BGMApp/BGMAppVolumesController.h
+++ b/BGMApp/BGMApp/BGMAppVolumesController.h
@@ -29,6 +29,11 @@
 
 #pragma clang assume_nonnull begin
 
+typedef struct BGMAppVolumeAndPan {
+    int volume;
+    int pan;
+} BGMAppVolumeAndPan;
+
 @interface BGMAppVolumesController : NSObject
 
 - (id) initWithMenu:(NSMenu*)menu
@@ -44,6 +49,9 @@ forAppWithProcessID:(pid_t)processID
 - (void) setPanPosition:(SInt32)pan
     forAppWithProcessID:(pid_t)processID
                bundleID:(NSString* __nullable)bundleID;
+
+- (BGMAppVolumeAndPan) getVolumeAndPanForApp:(NSRunningApplication *)app;
+- (void) setVolumeAndPan:(BGMAppVolumeAndPan)volumeAndPan forApp:(NSRunningApplication*)app;
 
 @end
 

--- a/BGMApp/BGMApp/BGMAppVolumesController.mm
+++ b/BGMApp/BGMApp/BGMAppVolumesController.mm
@@ -40,11 +40,6 @@
 
 #pragma clang assume_nonnull begin
 
-typedef struct BGMAppVolumeAndPan {
-    int volume;
-    int pan;
-} BGMAppVolumeAndPan;
-
 @implementation BGMAppVolumesController {
     // The App Volumes UI.
     BGMAppVolumes* appVolumes;
@@ -101,6 +96,20 @@ typedef struct BGMAppVolumeAndPan {
                                initialVolume:initial.volume
                                   initialPan:initial.pan];
         }
+    }
+}
+
+- (BGMAppVolumeAndPan) getVolumeAndPanForApp:(NSRunningApplication *)app {
+    return [appVolumes getVolumeAndPanForApp:app];
+}
+
+- (void) setVolumeAndPan:(BGMAppVolumeAndPan)volumeAndPan forApp:(NSRunningApplication*)app {
+    [appVolumes setVolumeAndPan:volumeAndPan forApp:app];
+    if (volumeAndPan.volume != -1) {
+        [self setVolume:volumeAndPan.volume forAppWithProcessID:app.processIdentifier bundleID:app.bundleIdentifier];
+    }
+    if (volumeAndPan.pan != -1) {
+        [self setPanPosition:volumeAndPan.pan forAppWithProcessID:app.processIdentifier bundleID:app.bundleIdentifier];
     }
 }
 

--- a/BGMApp/BGMApp/Scripting/BGMASApplication.h
+++ b/BGMApp/BGMApp/Scripting/BGMASApplication.h
@@ -1,0 +1,31 @@
+//
+//  BGMASApplication.h
+//  Background Music
+//
+//  Created by Marcus Wu on 3/17/21.
+//  Copyright © 2021 Background Music contributors. All rights reserved.
+//
+
+// Local Includes
+#import "BGMAppVolumesController.h"
+
+// System Includes
+#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BGMASApplication : NSObject
+
+- (instancetype) initWithApplication:(NSRunningApplication*)app
+                          volumeController:(BGMAppVolumesController*)volumeController
+                     parentSpecifier:(NSScriptObjectSpecifier* __nullable)parentSpecifier
+                               index:(int)i;
+
+@property (readonly) NSString* name;
+@property int volume;
+@property int pan;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BGMApp/BGMApp/Scripting/BGMASApplication.h
+++ b/BGMApp/BGMApp/Scripting/BGMASApplication.h
@@ -20,7 +20,8 @@
 //  Copyright © 2017 Kyle Neideck
 //  Created by Marcus Wu on 3/17/21.
 //
-//  An AppleScript class for volume and pan settings on for running applications.
+//  An AppleScript class for volume and pan settings for running applications.
+//
 
 
 // Local Includes

--- a/BGMApp/BGMApp/Scripting/BGMASApplication.h
+++ b/BGMApp/BGMApp/Scripting/BGMASApplication.h
@@ -17,8 +17,7 @@
 //  BGMASApplication.h
 //  BGMApp
 //
-//  Copyright © 2017 Kyle Neideck
-//  Created by Marcus Wu on 3/17/21.
+//  Copyright © 2021 Marcus Wu
 //
 //  An AppleScript class for volume and pan settings for running applications.
 //

--- a/BGMApp/BGMApp/Scripting/BGMASApplication.h
+++ b/BGMApp/BGMApp/Scripting/BGMASApplication.h
@@ -1,10 +1,27 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
 //
 //  BGMASApplication.h
-//  Background Music
+//  BGMApp
 //
+//  Copyright © 2017 Kyle Neideck
 //  Created by Marcus Wu on 3/17/21.
-//  Copyright © 2021 Background Music contributors. All rights reserved.
 //
+//  An AppleScript class for volume and pan settings on for running applications.
+
 
 // Local Includes
 #import "BGMAppVolumesController.h"

--- a/BGMApp/BGMApp/Scripting/BGMASApplication.m
+++ b/BGMApp/BGMApp/Scripting/BGMASApplication.m
@@ -1,0 +1,69 @@
+//
+//  BGMASApplication.m
+//  Background Music
+//
+//  Created by Marcus Wu on 3/17/21.
+//  Copyright © 2021 Background Music contributors. All rights reserved.
+//
+
+// Self Include
+#import "BGMASApplication.h"
+
+@implementation BGMASApplication {
+    NSScriptObjectSpecifier* parentSpecifier;
+    NSRunningApplication *application;
+    BGMAppVolumesController* appVolumesController;
+    int index;
+}
+
+- (instancetype) initWithApplication:(NSRunningApplication*)app
+                          volumeController:(BGMAppVolumesController*)volumeController
+                     parentSpecifier:(NSScriptObjectSpecifier* __nullable)parent
+                               index:(int)i {
+    if ((self = [super init])) {
+        parentSpecifier = parent;
+        application = app;
+        appVolumesController = volumeController;
+        index = i;
+    }
+
+    return self;
+}
+
+- (NSString*) name {
+    return [NSString stringWithFormat:@"%@", [application localizedName]];
+}
+
+- (int) volume {
+    return [appVolumesController getVolumeAndPanForApp:application].volume;
+}
+
+- (void) setVolume:(int)vol {
+    BGMAppVolumeAndPan volume = {
+        .volume = vol,
+        .pan = -1
+    };
+    [appVolumesController setVolumeAndPan:volume forApp:application];
+}
+
+- (int) pan {
+    return [appVolumesController getVolumeAndPanForApp:application].pan;
+}
+
+- (void) setPan:(int)pan {
+    BGMAppVolumeAndPan thePan = {
+        .volume = -1,
+        .pan = pan
+    };
+    [appVolumesController setVolumeAndPan:thePan forApp:application];
+}
+
+- (NSScriptObjectSpecifier* __nullable) objectSpecifier {
+    NSScriptClassDescription* parentClassDescription = [parentSpecifier keyClassDescription];
+    return [[NSNameSpecifier alloc] initWithContainerClassDescription:parentClassDescription
+                                                   containerSpecifier:parentSpecifier
+                                                                  key:@"applications"
+                                                                 name:self.name];
+}
+
+@end

--- a/BGMApp/BGMApp/Scripting/BGMASApplication.m
+++ b/BGMApp/BGMApp/Scripting/BGMASApplication.m
@@ -17,8 +17,7 @@
 //  BGMASApplication.mm
 //  BGMApp
 //
-//  Copyright © 2017 Kyle Neideck
-//  Created by Marcus Wu on 3/17/21.
+//  Copyright © 2021 Marcus Wu
 //
 
 // Self Include

--- a/BGMApp/BGMApp/Scripting/BGMASApplication.m
+++ b/BGMApp/BGMApp/Scripting/BGMASApplication.m
@@ -1,9 +1,24 @@
+// This file is part of Background Music.
 //
-//  BGMASApplication.m
-//  Background Music
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
 //
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGMASApplication.mm
+//  BGMApp
+//
+//  Copyright © 2017 Kyle Neideck
 //  Created by Marcus Wu on 3/17/21.
-//  Copyright © 2021 Background Music contributors. All rights reserved.
 //
 
 // Self Include

--- a/BGMApp/BGMApp/Scripting/BGMASApplication.m
+++ b/BGMApp/BGMApp/Scripting/BGMASApplication.m
@@ -14,7 +14,7 @@
 // along with Background Music. If not, see <http://www.gnu.org/licenses/>.
 
 //
-//  BGMASApplication.mm
+//  BGMASApplication.m
 //  BGMApp
 //
 //  Copyright © 2021 Marcus Wu

--- a/BGMApp/BGMApp/Scripting/BGMApp.sdef
+++ b/BGMApp/BGMApp/Scripting/BGMApp.sdef
@@ -27,6 +27,7 @@
                       type="boolean"
                       access="rw"
                       description="Is this the device to be used for audio output?">
+		<synonym name="default"/>
                 <cocoa key="selected"/>
             </property>
         </class>

--- a/BGMApp/BGMApp/Scripting/BGMApp.sdef
+++ b/BGMApp/BGMApp/Scripting/BGMApp.sdef
@@ -9,8 +9,7 @@
         <class name="output device"
                code="aDev"
                description="A hardware device that can play audio"
-               plural="output devices"
-               inherits="item">
+               plural="output devices">
             <synonym name="audio device"/>
 
             <cocoa class="BGMASOutputDevice"/>
@@ -19,14 +18,49 @@
                       code="pnam"
                       description="The name of the output device."
                       type="text"
-                      access="r"/>
+                      access="r">
+                <cocoa key="name"/>
+            </property>
 
             <property name="selected"
                       code="Slcd"
                       type="boolean"
                       access="rw"
                       description="Is this the device to be used for audio output?">
-                <synonym name="default"/>
+                <cocoa key="selected"/>
+            </property>
+        </class>
+
+        <class name="audio application"
+               code="aApp"
+               description="An application that can play audio"
+               plural="audio applications">
+            <synonym name="audio app"/>
+
+            <cocoa class="BGMASApplication"/>
+
+            <property name="name"
+                      code="pnam"
+                      description="The name of the application."
+                      type="text"
+                      access="r">
+                <cocoa key="name"/>
+            </property>
+
+            <property name="vol"
+                      code="pVol"
+                      type="integer"
+                      access="rw"
+                      description="The volume setting of the application">
+                <cocoa key="volume"/>
+            </property>
+
+            <property name="pan"
+                      code="pPan"
+                      type="integer"
+                      access="rw"
+                      description="The pan setting of the application">
+                <cocoa key="pan"/>
             </property>
         </class>
 
@@ -48,10 +82,22 @@
 
                 <cocoa key="selectedOutputDevice"/>
             </property>
+            <property name="output volume"
+                type="real"
+                code="oVol"
+                access="rw"
+                description="The main output volume">
+                <synonym name="main volume"/>
+
+                <cocoa key="mainVolume"/>
+            </property>
 
             <!-- Unintuitively, this is for the array of output devices. -->
             <element type="output device" access="r">
                 <cocoa key="outputDevices"/>
+            </element>
+            <element type="audio application" access="r">
+                <cocoa key="applications"/>
             </element>
         </class>
     </suite>

--- a/BGMApp/BGMApp/Scripting/BGMAppDelegate+AppleScript.h
+++ b/BGMApp/BGMApp/Scripting/BGMAppDelegate+AppleScript.h
@@ -24,6 +24,7 @@
 
 // Local Includes
 #import "BGMASOutputDevice.h"
+#import "BGMASApplication.h"
 
 // System Includes
 #import <Foundation/Foundation.h>
@@ -37,6 +38,8 @@
 
 @property BGMASOutputDevice* selectedOutputDevice;
 @property (readonly) NSArray<BGMASOutputDevice*>* outputDevices;
+@property double mainVolume;
+@property (readonly) NSArray<BGMASApplication*>* applications;
 
 @end
 

--- a/BGMApp/BGMApp/Scripting/BGMAppDelegate+AppleScript.mm
+++ b/BGMApp/BGMApp/Scripting/BGMAppDelegate+AppleScript.mm
@@ -30,6 +30,7 @@
 #import "CAHALAudioSystemObject.h"
 #import "CAAutoDisposer.h"
 
+const AudioObjectPropertyScope kScope                   = kAudioDevicePropertyScopeOutput;
 
 #pragma clang assume_nonnull begin
 
@@ -43,7 +44,7 @@
                  [key UTF8String]);
     }
 
-    return [@[@"selectedOutputDevice", @"outputDevices"] containsObject:key];
+    return [@[@"selectedOutputDevice", @"outputDevices", @"mainVolume", @"applications"] containsObject:key];
 }
 
 - (BGMASOutputDevice*) selectedOutputDevice {
@@ -81,6 +82,29 @@
     }
 
     return outputDevices;
+}
+
+- (double) mainVolume {
+    BGMAudioDevice bgmDevice = [self.audioDevices bgmDevice];
+    return bgmDevice.GetVolumeControlScalarValue(kScope, kMasterChannel);
+}
+
+- (void) setMainVolume:(double)mainVolume {
+    BGMAudioDevice bgmDevice = [self.audioDevices bgmDevice];
+    bgmDevice.SetMasterVolumeScalar(kScope, (Float32)mainVolume);
+}
+
+- (NSArray<BGMASApplication*>*) applications {
+    NSArray<NSRunningApplication*>* apps = [[NSWorkspace sharedWorkspace] runningApplications];
+    NSMutableArray<BGMASApplication*>* applications = [NSMutableArray arrayWithCapacity:[apps count]];
+
+    for (UInt32 i = 0; i < [apps count]; i++) {
+        BGMASApplication *app = [[BGMASApplication alloc] initWithApplication:apps[i] volumeController:self.appVolumes parentSpecifier:[self objectSpecifier] index:i];
+
+        [applications addObject:app];
+    }
+
+    return applications;
 }
 
 @end

--- a/BGMApp/BGMApp/Scripting/BGMAppDelegate+AppleScript.mm
+++ b/BGMApp/BGMApp/Scripting/BGMAppDelegate+AppleScript.mm
@@ -92,6 +92,7 @@ const AudioObjectPropertyScope kScope                   = kAudioDevicePropertySc
 - (void) setMainVolume:(double)mainVolume {
     BGMAudioDevice bgmDevice = [self.audioDevices bgmDevice];
     bgmDevice.SetMasterVolumeScalar(kScope, (Float32)mainVolume);
+    [self.outputVolumeSlider setFloatValue:(float)mainVolume];
 }
 
 - (NSArray<BGMASApplication*>*) applications {


### PR DESCRIPTION
These changes allow for additional scripting such as:
```
tell application "Background Music"
	set selected output device to first output device whose name is equal to "Built-in Output"
	
	set vol of (a reference to (the first audio application whose name is equal to "zoom.us")) to 75
	set pan of (a reference to (the first audio application whose name is equal to "zoom.us")) to 0
	
	set output volume to 0.5
end tell
```
#326
#449 