### PR TITLE
Remove python 2 usage

### DIFF
--- a/BGMApp/BGMXPCHelper/safe_install_dir.sh
+++ b/BGMApp/BGMXPCHelper/safe_install_dir.sh
@@ -71,7 +71,7 @@ check_dir() {
     pushd . > /dev/null
 
     # Normalize the path and follow symlinks.
-    REAL_PATH=$(python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$1")
+    REAL_PATH=$(cd "$1" && pwd -P)
     cd "${REAL_PATH}"
 
     DIR_IS_SAFE=0

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -519,7 +519,6 @@ log_debug_info() {
         uname -mrsv >> ${LOG_FILE} 2>&1
 
         /bin/bash --version >> ${LOG_FILE} 2>&1
-        /usr/bin/env python --version >> ${LOG_FILE} 2>&1
 
         echo "On git branch: $(git rev-parse --abbrev-ref HEAD 2>&1)" >> ${LOG_FILE}
         echo "Most recent commit: $(git rev-parse HEAD 2>&1)" \


### PR DESCRIPTION
Possible fix for #590. Python 2 was removed from macOS in 12.3, so the install script would fail. This replaces the usage of python in obtaining the realpath of a directory with bash commands to do the same.

Note that I have not compiled or tested this, I've only run the python and bash commands in the terminal and observed the same output.