### PR TITLE
add Microsoft Edge to `ResponsibleBundleIDsOf`

### DIFF
--- a/BGMApp/BGMApp/BGMBackgroundMusicDevice.cpp
+++ b/BGMApp/BGMApp/BGMBackgroundMusicDevice.cpp
@@ -241,7 +241,9 @@ BGMBackgroundMusicDevice::ResponsibleBundleIDsOf(CACFString inParentBundleID)
         // Skype
         { "com.skype.skype", { "com.skype.skype.Helper" } },
         // Google Chrome
-        { "com.google.Chrome", { "com.google.Chrome.helper" } }
+        { "com.google.Chrome", { "com.google.Chrome.helper" } },
+        // Microsoft Edge
+        { "com.microsoft.edgemac", { "com.microsoft.edgemac.helper" } }
     };
 
     // Parallels' VM "dock helper" apps have bundle IDs like


### PR DESCRIPTION
* resolve #474 

I know nothing about MacOS development but thanks to your [Wiki page](../wikis/App-Volumes-Fixes) I managed to do it.
Build & test was successful on my local environment. (Apple Silicon (M1 Pro), MacOS 12.3.1, Macbook Pro (2021, 14-inch))