### PR TITLE
Update references to `System Preferences`

### DIFF
--- a/BGMApp/BGMApp/_uninstall-non-interactive.sh
+++ b/BGMApp/BGMApp/_uninstall-non-interactive.sh
@@ -153,7 +153,7 @@ sleep 3
 
 # TODO: What if they only have one audio device?
 echo ""
-echo "${bold}Done! Toggle your audio output device in the Sound section of System Preferences to finish" \
+echo "${bold}Done! Toggle your audio output device in the Sound section of System Settings to finish" \
      "uninstalling. (Or just restart your computer.)${normal}"
 
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -13,7 +13,7 @@ the virtual device to the real output device and a few other things. The virtual
 ## Summary
 
 From the user's perspective, BGMDevice appears as one input device and one output device, both named "Background Music".
-They're shown in `System Preferences > Sound` along with the real audio devices.
+They're shown in `System Settings > Sound` along with the real audio devices.
 
 When you start BGMApp, it sets BGMDevice as your system's default output device so the system (i.e. Core Audio) will
 start sending all<sup id="a2">[2](#f2)</sup> your audio data to BGMDriver. BGMDriver plays that audio on BGMDevice's

--- a/MANUAL-UNINSTALL.md
+++ b/MANUAL-UNINSTALL.md
@@ -16,7 +16,7 @@
   ```shell
   sudo killall coreaudiod
   ```
-- Go to the Sound section in System Preferences and change your default output device at least once. (If you only have
+- Go to the Sound section in System Settings and change your default output device at least once. (If you only have
   one device now, either use `Audio MIDI Setup.app` to create a temporary aggregate device, restart any audio apps that
   have stopped working or just restart your system.)
   

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ brew install --cask background-music-pre
 # Run / Configure
 
 Just run `Applications > Background Music.app`! **Background Music** sets itself as your default output device under
-`System Preferences > Sound` when it starts up (and sets it back on Quit).
+`System Settings > Sound` when it starts up (and sets it back on Quit).
 
 ### Launch at Startup (Optional)
 
-Add **Background Music** to `System Preferences > Users & Groups > Current User > Login Items`.
+Add **Background Music** to `System Settings > Users & Groups > Current User > Login Items`.
 
 # Installing from Source Code
 
@@ -154,12 +154,12 @@ To manually uninstall, see [MANUAL_UNINSTALL.md](https://github.com/kyleneideck/
 
 # Troubleshooting
 
-If Background Music crashes and your audio stops working, open `System Preferences > Sound` and change your
+If Background Music crashes and your audio stops working, open `System Settings > Sound` and change your
 system's default output device to something other than the **Background Music device**. If it already is, then
 change the default device and then change it back again.
 
 Make sure you allow "microphone access" when you first run Background Music. If you denied it, go to
-`System Preferences > Security & Privacy > Privacy > Microphone`, find Background Music in the list
+`System Settings > Security & Privacy > Privacy > Microphone`, find Background Music in the list
 and check the box next to it. Background Music doesn't actually listen to your microphone. It needs
 the permission because it gets your system audio from its virtual input device, which macOS counts
 as a microphone. (We're working on it in [#177](/../../issues/177).)
@@ -185,7 +185,7 @@ meeting volume.
     - To disable this, uncheck *Pause iTunes during calls* on the **General** tab of **Skype**'s preferences.
 
 - **Plugging in or unplugging headphones when Background Music isn't running causes silence in the system audio.**
-    - Navigate to **System Preferences > Sound**. Click the **Output** tab and change your default output device to something other than the **Background Music** device. Alternatively, press **Option + Click** on the sound icon within the menu bar to select a different output device. This happens when macOS remembers that the **Background Music** device was your default audio device the last time you used (or didn't use) headphones.
+    - Navigate to **System Settings > Sound**. Click the **Output** tab and change your default output device to something other than the **Background Music** device. Alternatively, press **Option + Click** on the sound icon within the menu bar to select a different output device. This happens when macOS remembers that the **Background Music** device was your default audio device the last time you used (or didn't use) headphones.
 
 - **[A Chrome bug](https://bugs.chromium.org/p/chromium/issues/detail?id=557620) stops Chrome from switching to the Background Music device after you open Background Music.**
     - Chrome's audio will still play, but **Background Music** won't be aware of it.

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -136,7 +136,7 @@ BUILD_FAILED_ERROR_MSG="A build command failed. Probably a compilation error."
 BGMAPP_FAILED_TO_START_ERROR_MSG="Background Music (${APP_PATH}/${APP_DIR}) didn't seem to start \
 up. It might just be taking a while.
 
-If it didn't install correctly, you'll need to open the Sound control panel in System Preferences \
+If it didn't install correctly, you'll need to open the Sound control panel in System Settings \
 and change your output device at least once. Your sound probably won't work until you do. (Or you \
 restart your computer.)
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -63,7 +63,7 @@ if [ "$user_prompt" == "y" ] || [ "$user_prompt" == "Y" ]; then
   # Invalidate sudo ticket
   sudo -k
 
-  # Open System Preferences and go to Sound > Output.
+  # Open System Settings and go to Sound > Output.
   osascript -e 'tell application id "com.apple.systempreferences"
                   activate
                   reveal anchor "output" of pane id "com.apple.preference.sound"


### PR DESCRIPTION
As of MacOS 13, System Preferences is known as System Settings. This PR updates all user facing references to System Preferences, using the new nomenclature.