### PR TITLE
Fix Login Items path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Just run `Applications > Background Music.app`! **Background Music** sets itself
 
 ### Launch at Startup (Optional)
 
-Add **Background Music** to `System Settings > Users & Groups > Current User > Login Items`.
+Add **Background Music** to `System Settings > General > Login Items`.
 
 # Installing from Source Code
 


### PR DESCRIPTION
The `Login Items` menu is at the `System Settings > General > Login Items` path on macOS `Sonoma 14.3`, and not at `System Settings > Users & Groups > Current User > Login Items`.

This PR updates the `README.md` with the correct path.

Reference: 
<img width="715" alt="SCR-20240220-kfgt-2" src="https://github.com/kyleneideck/BackgroundMusic/assets/83340568/cc5b798f-0f5c-4515-8d1e-4c78e4f5b1bb">
