### PR TITLE
Add arc browser support

### DIFF
--- a/BGMApp/BGMApp/BGMBackgroundMusicDevice.cpp
+++ b/BGMApp/BGMApp/BGMBackgroundMusicDevice.cpp
@@ -243,7 +243,9 @@ BGMBackgroundMusicDevice::ResponsibleBundleIDsOf(CACFString inParentBundleID)
         // Google Chrome
         { "com.google.Chrome", { "com.google.Chrome.helper" } },
         // Microsoft Edge
-        { "com.microsoft.edgemac", { "com.microsoft.edgemac.helper" } }
+        { "com.microsoft.edgemac", { "com.microsoft.edgemac.helper" } },
+        // Arc
+        { "company.thebrowser.Browser", { "company.thebrowser.browser.helper" } }
     };
 
     // Parallels' VM "dock helper" apps have bundle IDs like


### PR DESCRIPTION
Hi. I made a small change to your array that allows volume control of child processes to add support for the arc browser. Best regards Manzick
P.S. I'm not the only one reproducing the problem:  https://github.com/kyleneideck/BackgroundMusic/issues/735