### PR TITLE
Fix volume icon on menu bar not centered

### DIFF
--- a/BGMApp/BGMApp/BGMStatusBarItem.mm
+++ b/BGMApp/BGMApp/BGMStatusBarItem.mm
@@ -125,10 +125,17 @@ static CGFloat const kVolumeIconAdditionalVerticalPadding = 0.075;
 - (void) initIcons {
     // Load the icons.
     fermataIcon = [NSImage imageNamed:@"FermataIcon"];
-    volumeIcon0SoundWaves = [NSImage imageNamed:@"Volume0"];
-    volumeIcon1SoundWave = [NSImage imageNamed:@"Volume1"];
-    volumeIcon2SoundWaves = [NSImage imageNamed:@"Volume2"];
-    volumeIcon3SoundWaves = [NSImage imageNamed:@"Volume3"];
+    if (@available(macOS 11.0, *)) {
+        volumeIcon0SoundWaves = [NSImage imageWithSystemSymbolName:@"speaker.fill" accessibilityDescription:nil];
+        volumeIcon1SoundWave = [NSImage imageWithSystemSymbolName:@"speaker.wave.1.fill" accessibilityDescription:nil];
+        volumeIcon2SoundWaves = [NSImage imageWithSystemSymbolName:@"speaker.wave.2.fill" accessibilityDescription:nil];
+        volumeIcon3SoundWaves = [NSImage imageWithSystemSymbolName:@"speaker.wave.3.fill" accessibilityDescription:nil];
+    } else {
+        volumeIcon0SoundWaves = [NSImage imageNamed:@"Volume0"];
+        volumeIcon1SoundWave = [NSImage imageNamed:@"Volume1"];
+        volumeIcon2SoundWaves = [NSImage imageNamed:@"Volume2"];
+        volumeIcon3SoundWaves = [NSImage imageNamed:@"Volume3"];
+    }
 
     // Set the icons' sizes.
     NSRect statusBarItemFrame;


### PR DESCRIPTION
I noticed that the volume icon is not centered on the menu bar, instead of replacing the asset itself i used apple's SF Symbols volume assets, since it is only available on macos 11> i have added a condition for it. 

# Before 


https://github.com/user-attachments/assets/33e79eb2-15be-49f3-a90b-5d0fe58b09bf

# After


https://github.com/user-attachments/assets/7f7e465b-7442-4b8d-93eb-f0b8eb2da1e2

