### PR TITLE
fix crash in BGMPlayThrough::IsRunningSomewhereOtherThanBGMApp

### DIFF
--- a/BGMApp/BGMApp/BGMPlayThrough.cpp
+++ b/BGMApp/BGMApp/BGMPlayThrough.cpp
@@ -933,9 +933,8 @@ void    BGMPlayThrough::HandleBGMDeviceIsRunningSomewhereOtherThanBGMApp(BGMPlay
 // static
 bool    BGMPlayThrough::IsRunningSomewhereOtherThanBGMApp(const BGMAudioDevice& inBGMDevice)
 {
-    return CFBooleanGetValue(
-        static_cast<CFBooleanRef>(
-            inBGMDevice.GetPropertyData_CFType(kBGMRunningSomewhereOtherThanBGMAppAddress)));
+    auto type = inBGMDevice.GetPropertyData_CFType(kBGMRunningSomewhereOtherThanBGMAppAddress);
+    return type && CFBooleanGetValue(static_cast<CFBooleanRef>(type));
 }
 
 #pragma mark IOProcs


### PR DESCRIPTION
At that time, when using the following tools to play alternately, it would crash

- Chrome plays YouTube
- ffmpeg capture BackgroundMusic Device: 
  `ffmpeg -f avfoundation -i :2 /tmp/hello.wav -y`
- ffplay plays:
  `ffplay /tmp/hello.wav`

This PR fixes it