### PR TITLE
feat: add IINA auto-pause support via mpv IPC socket

### DIFF
--- a/BGMApp/BGMApp.xcodeproj/project.pbxproj
+++ b/BGMApp/BGMApp.xcodeproj/project.pbxproj
@@ -91,6 +91,9 @@
 		1C8D830520423E1C00A838F2 /* BGMSwinsian.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D8302204238DB00A838F2 /* BGMSwinsian.m */; };
 		1C8D830620423E2400A838F2 /* BGMSwinsian.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D8302204238DB00A838F2 /* BGMSwinsian.m */; };
 		1C8D830B2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D830A2042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMGooglePlayMusicDesktopPlayer.m"; }; };
+		36D6EE4CFE6ACFCB3FDB5E62 /* BGIINA.m in Sources */ = {isa = PBXBuildFile; fileRef = 63C2879EFFF7D8F3FC1140AA /* BGIINA.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGIINA.m"; }; };
+		89BAD0EFE52C3B793228D0E9 /* BGIINA.m in Sources */ = {isa = PBXBuildFile; fileRef = 63C2879EFFF7D8F3FC1140AA /* BGIINA.m */; };
+		562EBED289DCDF25B8D0E38E /* BGIINA.m in Sources */ = {isa = PBXBuildFile; fileRef = 63C2879EFFF7D8F3FC1140AA /* BGIINA.m */; };
 		1C8D830C2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D830A2042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.m */; };
 		1C8D830E2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js in Resources */ = {isa = PBXBuildFile; fileRef = 1C8D830D2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js */; };
 		1C8D830F2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js in Resources */ = {isa = PBXBuildFile; fileRef = 1C8D830D2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js */; };
@@ -345,6 +348,8 @@
 		1C8D8303204238DB00A838F2 /* BGMSwinsian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGMSwinsian.h; path = "Music Players/BGMSwinsian.h"; sourceTree = "<group>"; };
 		1C8D83092042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGMGooglePlayMusicDesktopPlayer.h; path = "Music Players/BGMGooglePlayMusicDesktopPlayer.h"; sourceTree = "<group>"; };
 		1C8D830A2042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BGMGooglePlayMusicDesktopPlayer.m; path = "Music Players/BGMGooglePlayMusicDesktopPlayer.m"; sourceTree = "<group>"; };
+		4A419E5A61212063F7D26408 /* BGIINA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGIINA.h; path = "Music Players/BGIINA.h"; sourceTree = "<group>"; };
+		63C2879EFFF7D8F3FC1140AA /* BGIINA.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BGIINA.m; path = "Music Players/BGIINA.m"; sourceTree = "<group>"; };
 		1C8D830D2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = GooglePlayMusicDesktopPlayer.js; path = "Music Players/GooglePlayMusicDesktopPlayer.js"; sourceTree = "<group>"; };
 		1C9258452090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BGMGooglePlayMusicDesktopPlayerConnection.h; path = "Music Players/BGMGooglePlayMusicDesktopPlayerConnection.h"; sourceTree = "<group>"; };
 		1C9258462090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BGMGooglePlayMusicDesktopPlayerConnection.m; path = "Music Players/BGMGooglePlayMusicDesktopPlayerConnection.m"; sourceTree = "<group>"; };
@@ -598,6 +603,8 @@
 				27F7D48F1D2483B100821C4B /* BGMDecibel.m */,
 				1C8D83092042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.h */,
 				1C8D830A2042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.m */,
+				4A419E5A61212063F7D26408 /* BGIINA.h */,
+				63C2879EFFF7D8F3FC1140AA /* BGIINA.m */,
 				1C9258452090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.h */,
 				1C9258462090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.m */,
 				1C2336DB1BEAB73F004C1C4E /* BGMiTunes.h */,
@@ -1121,6 +1128,7 @@
 				1CD410D41F9EDDAD0070A094 /* BGMAppVolumesController.mm in Sources */,
 				1C1962E41BC94E15008A4DF7 /* CARingBuffer.cpp in Sources */,
 				1C8D830B2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */,
+				36D6EE4CFE6ACFCB3FDB5E62 /* BGIINA.m in Sources */,
 				273F10DF1CC3D0B900C1C6DA /* BGMVOX.m in Sources */,
 				1CC1DF811BE5068A00FB8FE4 /* CACFArray.cpp in Sources */,
 				279F48771DD6D73A00768A85 /* BGMHermes.m in Sources */,
@@ -1182,6 +1190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1C8104B022AD082E00B35517 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */,
+				562EBED289DCDF25B8D0E38E /* BGIINA.m in Sources */,
 				1C8D830520423E1C00A838F2 /* BGMSwinsian.m in Sources */,
 				1CE03A58239B56740036908D /* BGMDebugLoggingMenuItem.m in Sources */,
 				1CACCF3A1F334447007F86CA /* BGMBackgroundMusicDevice.cpp in Sources */,
@@ -1283,6 +1292,7 @@
 				1C227C0B1FA4C48200A95B6D /* BGMAppVolumes.m in Sources */,
 				1CACCF3B1F334450007F86CA /* BGMBackgroundMusicDevice.cpp in Sources */,
 				1C8D830C2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */,
+				89BAD0EFE52C3B793228D0E9 /* BGIINA.m in Sources */,
 				1C3D36741ED90E8600F98E66 /* BGMDeviceControlsList.cpp in Sources */,
 				27FB8C301DE4758A0084DB9D /* BGMPlayThrough.cpp in Sources */,
 				27FB8C311DE4758A0084DB9D /* BGM_Utils.cpp in Sources */,

--- a/BGMApp/BGMApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/BGMApp/BGMApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+</Workspace>

--- a/BGMApp/BGMApp/Music Players/BGIINA.h
+++ b/BGMApp/BGMApp/Music Players/BGIINA.h
@@ -1,0 +1,32 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGIINA.h
+//  BGMApp
+//
+//  Copyright © 2024 Background Music contributors
+//
+//  IINA 播放器支持。通过 mpv IPC socket 控制播放。
+//  需要用户在 ~/.config/mpv/mpv.conf 中配置: input-ipc-server=/tmp/iina-mpv-socket
+//
+
+// Superclass/Protocol Import
+#import "BGMMusicPlayer.h"
+
+
+@interface BGIINA : BGMMusicPlayerBase<BGMMusicPlayer>
+
+@end

--- a/BGMApp/BGMApp/Music Players/BGIINA.m
+++ b/BGMApp/BGMApp/Music Players/BGIINA.m
@@ -1,0 +1,206 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGIINA.m
+//  BGMApp
+//
+//  Copyright © 2024 Background Music contributors
+//
+//  IINA 播放器支持。通过 mpv IPC socket 控制播放。
+//
+//  前提条件：用户需要在 ~/.config/mpv/mpv.conf 中配置：
+//    input-ipc-server=/tmp/iina-mpv-socket
+//
+//  IINA 基于 mpv，支持通过 Unix domain socket 发送 JSON IPC 命令来控制播放。
+//  参考：https://mpv.io/manual/stable/#json-ipc
+//
+
+// Self Include
+#import "BGIINA.h"
+
+// Local Includes
+#import "BGMAppWatcher.h"
+
+// PublicUtility Includes
+#import "CADebugMacros.h"
+
+// System Includes
+#import <Cocoa/Cocoa.h>
+#import <sys/socket.h>
+#import <sys/un.h>
+
+
+// mpv IPC socket 路径
+static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
+
+
+#pragma clang assume_nonnull begin
+
+@implementation BGIINA {
+    BGMAppWatcher* appWatcher;
+    BOOL _running;
+}
+
+- (instancetype) init {
+    if ((self = [super initWithMusicPlayerID:[BGMMusicPlayerBase makeID:@"41FE4E09-85FF-40F3-B336-5C973F4CCD86"]
+                                        name:@"IINA"
+                                    bundleID:@"com.colliderli.iina"])) {
+        BGIINA* __weak weakSelf = self;
+        appWatcher = [[BGMAppWatcher alloc]
+            initWithBundleID:@"com.colliderli.iina"
+                 appLaunched:^{
+                     BGIINA* strongSelf = weakSelf;
+                     if (strongSelf) {
+                         strongSelf->_running = YES;
+                         DebugMsg("BGIINA: IINA 已启动");
+                     }
+                 }
+               appTerminated:^{
+                   BGIINA* strongSelf = weakSelf;
+                   if (strongSelf) {
+                       strongSelf->_running = NO;
+                       DebugMsg("BGIINA: IINA 已退出");
+                   }
+               }];
+
+        NSArray<NSRunningApplication*>* running =
+            [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.colliderli.iina"];
+        _running = (running.count > 0);
+    }
+    return self;
+}
+
+#pragma mark BGMMusicPlayer
+
+- (BOOL) isRunning {
+    NSArray<NSRunningApplication*>* running =
+        [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.colliderli.iina"];
+    return running.count > 0;
+}
+
+- (BOOL) isPlaying {
+    if (!self.running) return NO;
+
+    // 通过 mpv IPC 查询播放状态
+    // get_property pause 返回 true 表示暂停中
+    NSData* response = [self sendMPVCommand:@[@"get_property", @"pause"]];
+    if (response) {
+        NSString* responseStr = [[NSString alloc] initWithData:response encoding:NSUTF8StringEncoding];
+        // 响应格式: {"data":false,"request_id":0,"error":"success"}
+        // data: false 表示未暂停（正在播放）
+        if ([responseStr containsString:@"\"data\":false"]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+- (BOOL) isPaused {
+    if (!self.running) return NO;
+
+    NSData* response = [self sendMPVCommand:@[@"get_property", @"pause"]];
+    if (response) {
+        NSString* responseStr = [[NSString alloc] initWithData:response encoding:NSUTF8StringEncoding];
+        if ([responseStr containsString:@"\"data\":true"]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+- (BOOL) pause {
+    if (!self.running) {
+        DebugMsg("BGIINA::pause: IINA 未运行");
+        return NO;
+    }
+
+    DebugMsg("BGIINA::pause: 通过 mpv IPC 暂停 IINA");
+    NSData* response = [self sendMPVCommand:@[@"set_property", @"pause", @YES]];
+    return response != nil;
+}
+
+- (BOOL) unpause {
+    if (!self.running) {
+        DebugMsg("BGIINA::unpause: IINA 未运行");
+        return NO;
+    }
+
+    DebugMsg("BGIINA::unpause: 通过 mpv IPC 恢复 IINA");
+    NSData* response = [self sendMPVCommand:@[@"set_property", @"pause", @NO]];
+    return response != nil;
+}
+
+#pragma mark mpv IPC
+
+- (NSData* __nullable) sendMPVCommand:(NSArray*)command {
+    // 检查 socket 文件是否存在
+    if (![[NSFileManager defaultManager] fileExistsAtPath:kIINAMPVSocketPath]) {
+        DebugMsg("BGIINA::sendMPVCommand: mpv IPC socket 不存在: %s", kIINAMPVSocketPath.UTF8String);
+        return nil;
+    }
+
+    // 创建 Unix domain socket 连接
+    int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock < 0) {
+        DebugMsg("BGIINA::sendMPVCommand: 创建 socket 失败");
+        return nil;
+    }
+
+    // 设置 socket 地址
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, [kIINAMPVSocketPath UTF8String], sizeof(addr.sun_path) - 1);
+
+    // 连接到 socket
+    if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        DebugMsg("BGIINA::sendMPVCommand: 连接 socket 失败");
+        close(sock);
+        return nil;
+    }
+
+    // 构建 JSON IPC 命令
+    // 格式: {"command": [cmd, arg1, arg2, ...]}
+    NSDictionary* ipcCommand = @{@"command": command};
+    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:ipcCommand options:0 error:nil];
+    NSString* jsonCommand = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    jsonCommand = [jsonCommand stringByAppendingString:@"\n"];
+
+    // 发送命令
+    ssize_t sent = send(sock, [jsonCommand UTF8String], [jsonCommand length], 0);
+    if (sent < 0) {
+        DebugMsg("BGIINA::sendMPVCommand: 发送命令失败");
+        close(sock);
+        return nil;
+    }
+
+    // 接收响应
+    char buffer[4096];
+    ssize_t received = recv(sock, buffer, sizeof(buffer) - 1, 0);
+    close(sock);
+
+    if (received <= 0) {
+        DebugMsg("BGIINA::sendMPVCommand: 未收到响应");
+        return nil;
+    }
+
+    buffer[received] = '\0';
+    return [NSData dataWithBytes:buffer length:received];
+}
+
+@end
+
+#pragma clang assume_nonnull end

--- a/BGMApp/BGMApp/Music Players/BGIINA.m
+++ b/BGMApp/BGMApp/Music Players/BGIINA.m
@@ -41,6 +41,8 @@
 #import <Cocoa/Cocoa.h>
 #import <sys/socket.h>
 #import <sys/un.h>
+#import <sys/stat.h>
+#import <unistd.h>
 
 
 // mpv IPC socket 路径
@@ -145,10 +147,41 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
 
 #pragma mark mpv IPC
 
+- (BOOL) isValidSocket:(NSString*)path {
+    // 使用 lstat 而不是 stat，避免跟踪 symlink
+    struct stat socketStat;
+    if (lstat([path UTF8String], &socketStat) != 0) {
+        return NO;
+    }
+
+    // 验证是否是 socket 文件
+    if (!S_ISSOCK(socketStat.st_mode)) {
+        DebugMsg("BGIINA::isValidSocket: 文件不是 socket");
+        return NO;
+    }
+
+    // 验证所有者是否是当前用户
+    uid_t currentUid = getuid();
+    if (socketStat.st_uid != currentUid) {
+        DebugMsg("BGIINA::isValidSocket: socket 所有者不匹配 (expected=%d, actual=%d)",
+                 currentUid, socketStat.st_uid);
+        return NO;
+    }
+
+    // 验证权限是否安全（只允许所有者读写）
+    mode_t mode = socketStat.st_mode & 07777;
+    if (mode != 0600 && mode != 0700) {
+        DebugMsg("BGIINA::isValidSocket: socket 权限不安全 (mode=%o)", mode);
+        return NO;
+    }
+
+    return YES;
+}
+
 - (NSData* __nullable) sendMPVCommand:(NSArray*)command {
-    // 检查 socket 文件是否存在
-    if (![[NSFileManager defaultManager] fileExistsAtPath:kIINAMPVSocketPath]) {
-        DebugMsg("BGIINA::sendMPVCommand: mpv IPC socket 不存在: %s", kIINAMPVSocketPath.UTF8String);
+    // 安全验证：检查 socket 文件是否合法
+    if (![self isValidSocket:kIINAMPVSocketPath]) {
+        DebugMsg("BGIINA::sendMPVCommand: mpv IPC socket 验证失败");
         return nil;
     }
 
@@ -170,6 +203,19 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
         DebugMsg("BGIINA::sendMPVCommand: 连接 socket 失败");
         close(sock);
         return nil;
+    }
+
+    // 验证连接的 peer credentials
+    struct xucred peerCred;
+    socklen_t credLen = sizeof(peerCred);
+    if (getsockopt(sock, 0, LOCAL_PEERCRED, &peerCred, &credLen) == 0) {
+        uid_t currentUid = getuid();
+        if (peerCred.cr_uid != currentUid) {
+            DebugMsg("BGIINA::sendMPVCommand: peer 身份验证失败 (expected=%d, actual=%d)",
+                     currentUid, peerCred.cr_uid);
+            close(sock);
+            return nil;
+        }
     }
 
     // 构建 JSON IPC 命令

--- a/BGMApp/BGMApp/Music Players/BGIINA.m
+++ b/BGMApp/BGMApp/Music Players/BGIINA.m
@@ -48,6 +48,8 @@
 
 // mpv IPC socket 路径
 static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
+// socket 超时时间（秒）
+static const NSTimeInterval kSocketTimeout = 5.0;
 
 
 #pragma clang assume_nonnull begin
@@ -99,13 +101,10 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
 
     // 通过 mpv IPC 查询播放状态
     // get_property pause 返回 true 表示暂停中
-    NSData* response = [self sendMPVCommand:@[@"get_property", @"pause"]];
-    if (response) {
-        NSDictionary* json = [NSJSONSerialization JSONObjectWithData:response options:0 error:nil];
-        if (json && [json[@"error"] isEqualToString:@"success"]) {
-            // data: false 表示未暂停（正在播放）
-            return [json[@"data"] boolValue] == NO;
-        }
+    NSDictionary* response = [self sendMPVGetProperty:@"pause"];
+    if (response && [response[@"error"] isEqualToString:@"success"]) {
+        // data: false 表示未暂停（正在播放）
+        return [response[@"data"] boolValue] == NO;
     }
     return NO;
 }
@@ -113,13 +112,10 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
 - (BOOL) isPaused {
     if (!self.running) return NO;
 
-    NSData* response = [self sendMPVCommand:@[@"get_property", @"pause"]];
-    if (response) {
-        NSDictionary* json = [NSJSONSerialization JSONObjectWithData:response options:0 error:nil];
-        if (json && [json[@"error"] isEqualToString:@"success"]) {
-            // data: true 表示暂停中
-            return [json[@"data"] boolValue] == YES;
-        }
+    NSDictionary* response = [self sendMPVGetProperty:@"pause"];
+    if (response && [response[@"error"] isEqualToString:@"success"]) {
+        // data: true 表示暂停中
+        return [response[@"data"] boolValue] == YES;
     }
     return NO;
 }
@@ -131,12 +127,7 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
     }
 
     DebugMsg("BGIINA::pause: 通过 mpv IPC 暂停 IINA");
-    NSData* response = [self sendMPVCommand:@[@"set_property", @"pause", @YES]];
-    if (response) {
-        NSDictionary* json = [NSJSONSerialization JSONObjectWithData:response options:0 error:nil];
-        return json && [json[@"error"] isEqualToString:@"success"];
-    }
-    return NO;
+    return [self sendMPVSetProperty:@"pause" value:@YES];
 }
 
 - (BOOL) unpause {
@@ -146,15 +137,39 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
     }
 
     DebugMsg("BGIINA::unpause: 通过 mpv IPC 恢复 IINA");
-    NSData* response = [self sendMPVCommand:@[@"set_property", @"pause", @NO]];
+    return [self sendMPVSetProperty:@"pause" value:@NO];
+}
+
+#pragma mark mpv IPC - 高级接口
+
+- (NSDictionary* __nullable) sendMPVGetProperty:(NSString*)property {
+    NSData* response = [self sendMPVCommand:@[@"get_property", property]];
     if (response) {
-        NSDictionary* json = [NSJSONSerialization JSONObjectWithData:response options:0 error:nil];
+        return [self parseResponse:response];
+    }
+    return nil;
+}
+
+- (BOOL) sendMPVSetProperty:(NSString*)property value:(id)value {
+    NSData* response = [self sendMPVCommand:@[@"set_property", property, value]];
+    if (response) {
+        NSDictionary* json = [self parseResponse:response];
         return json && [json[@"error"] isEqualToString:@"success"];
     }
     return NO;
 }
 
-#pragma mark mpv IPC
+- (NSDictionary* __nullable) parseResponse:(NSData*)data {
+    NSError* error = nil;
+    NSDictionary* json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    if (error) {
+        DebugMsg("BGIINA::parseResponse: JSON 解析失败: %s", error.localizedDescription.UTF8String);
+        return nil;
+    }
+    return json;
+}
+
+#pragma mark mpv IPC - 底层接口
 
 - (BOOL) isValidSocket:(NSString*)path {
     // 使用 lstat 而不是 stat，避免跟踪 symlink
@@ -196,6 +211,13 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
         DebugMsg("BGIINA::sendMPVCommand: 创建 socket 失败");
         return nil;
     }
+
+    // 设置 socket 超时
+    struct timeval tv;
+    tv.tv_sec = (long)kSocketTimeout;
+    tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
 
     // 设置 socket 地址
     struct sockaddr_un addr;

--- a/BGMApp/BGMApp/Music Players/BGIINA.m
+++ b/BGMApp/BGMApp/Music Players/BGIINA.m
@@ -100,11 +100,10 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
     // get_property pause 返回 true 表示暂停中
     NSData* response = [self sendMPVCommand:@[@"get_property", @"pause"]];
     if (response) {
-        NSString* responseStr = [[NSString alloc] initWithData:response encoding:NSUTF8StringEncoding];
-        // 响应格式: {"data":false,"request_id":0,"error":"success"}
-        // data: false 表示未暂停（正在播放）
-        if ([responseStr containsString:@"\"data\":false"]) {
-            return YES;
+        NSDictionary* json = [NSJSONSerialization JSONObjectWithData:response options:0 error:nil];
+        if (json && [json[@"error"] isEqualToString:@"success"]) {
+            // data: false 表示未暂停（正在播放）
+            return [json[@"data"] boolValue] == NO;
         }
     }
     return NO;
@@ -115,9 +114,10 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
 
     NSData* response = [self sendMPVCommand:@[@"get_property", @"pause"]];
     if (response) {
-        NSString* responseStr = [[NSString alloc] initWithData:response encoding:NSUTF8StringEncoding];
-        if ([responseStr containsString:@"\"data\":true"]) {
-            return YES;
+        NSDictionary* json = [NSJSONSerialization JSONObjectWithData:response options:0 error:nil];
+        if (json && [json[@"error"] isEqualToString:@"success"]) {
+            // data: true 表示暂停中
+            return [json[@"data"] boolValue] == YES;
         }
     }
     return NO;
@@ -131,7 +131,11 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
 
     DebugMsg("BGIINA::pause: 通过 mpv IPC 暂停 IINA");
     NSData* response = [self sendMPVCommand:@[@"set_property", @"pause", @YES]];
-    return response != nil;
+    if (response) {
+        NSDictionary* json = [NSJSONSerialization JSONObjectWithData:response options:0 error:nil];
+        return json && [json[@"error"] isEqualToString:@"success"];
+    }
+    return NO;
 }
 
 - (BOOL) unpause {
@@ -142,7 +146,11 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
 
     DebugMsg("BGIINA::unpause: 通过 mpv IPC 恢复 IINA");
     NSData* response = [self sendMPVCommand:@[@"set_property", @"pause", @NO]];
-    return response != nil;
+    if (response) {
+        NSDictionary* json = [NSJSONSerialization JSONObjectWithData:response options:0 error:nil];
+        return json && [json[@"error"] isEqualToString:@"success"];
+    }
+    return NO;
 }
 
 #pragma mark mpv IPC
@@ -168,12 +176,8 @@ static NSString* const kIINAMPVSocketPath = @"/tmp/iina-mpv-socket";
         return NO;
     }
 
-    // 验证权限是否安全（只允许所有者读写）
-    mode_t mode = socketStat.st_mode & 07777;
-    if (mode != 0600 && mode != 0700) {
-        DebugMsg("BGIINA::isValidSocket: socket 权限不安全 (mode=%o)", mode);
-        return NO;
-    }
+    // 注意：不检查 socket 权限，因为 mpv 默认创建 755 权限的 socket
+    // 安全性主要依赖 LOCAL_PEERCRED 验证（在 connect 后执行）
 
     return YES;
 }

--- a/BGMApp/BGMApp/Music Players/BGIINA.m
+++ b/BGMApp/BGMApp/Music Players/BGIINA.m
@@ -43,6 +43,7 @@
 #import <sys/un.h>
 #import <sys/stat.h>
 #import <unistd.h>
+#import <sys/ucred.h>
 
 
 // mpv IPC socket 路径

--- a/BGMApp/BGMApp/Music Players/BGMMusicPlayers.mm
+++ b/BGMApp/BGMApp/Music Players/BGMMusicPlayers.mm
@@ -36,6 +36,7 @@
 #import "BGMSwinsian.h"
 #import "BGMMusic.h"
 #import "BGMGooglePlayMusicDesktopPlayer.h"
+#import "BGIINA.h"
 
 
 #pragma clang assume_nonnull begin
@@ -58,7 +59,8 @@
                                                    [BGMDecibel class],
                                                    [BGMHermes class],
                                                    [BGMSwinsian class],
-                                                   [BGMMusic class] ];
+                                                   [BGMMusic class],
+                                                   [BGIINA class] ];
 
     // We only support Google Play Music Desktop Player on macOS 10.10 and higher.
     if (@available(macOS 10.10, *)) {


### PR DESCRIPTION
## Add IINA Auto-Pause Support

### Summary
Add auto-pause support for [IINA](https://iina.io/), a modern macOS media player based on mpv.

### Background
IINA is one of the most popular open-source media players on macOS. Unlike Spotify/iTunes/VLC, IINA does not support AppleScript or Scripting Bridge, which are the standard mechanisms used by Background Music to control music players.

After extensive research, we discovered that:
- IINA has no `.sdef` (Scripting Definition) file
- IINA's URL scheme (`iina://`) only supports `open` and `weblink` actions
- IINA does not respond to system media key events (IOHIDPostEvent)
- IINA does not respond to distributed notifications

However, IINA is built on top of **mpv** and supports mpv's **JSON IPC protocol** via Unix domain socket.

### Implementation
The solution uses mpv's IPC socket to communicate with IINA:

1. **`BGIINA.h/m`** - New music player class that implements the `BGMMusicPlayer` protocol
2. **Communication**: Uses Unix domain socket at `/tmp/iina-mpv-socket`
3. **Protocol**: mpv JSON IPC (`{"command": ["set_property", "pause", true]}`)
4. **Commands used**:
   - `get_property "pause"` - Query playback state
   - `set_property "pause", true` - Pause playback
   - `set_property "pause", false` - Resume playback

### User Configuration Required
Users need to create `~/.config/mpv/mpv.conf` with:
```
input-ipc-server=/tmp/iina-mpv-socket
```
Then restart IINA for the configuration to take effect.

### Files Changed
- `BGMApp/BGMApp/Music Players/BGIINA.h` (new)
- `BGMApp/BGMApp/Music Players/BGIINA.m` (new)
- `BGMApp/BGMApp/Music Players/BGMMusicPlayers.mm` (modified - add IINA import and registration)
- `BGMApp/BGMApp.xcodeproj/project.pbxproj` (modified - add new files)

### Testing
- **Tested on**: macOS (Apple Silicon)
- **IINA version**: 1.4.3
- **Test scenarios**:
  1. IINA playing video + browser audio → IINA pauses ✓
  2. Browser audio stops → IINA resumes ✓
  3. IINA closed → no errors ✓
  4. Socket not configured → graceful fallback ✓

### Limitations
- Requires manual mpv configuration (cannot be automated)
- Socket path is hardcoded to `/tmp/iina-mpv-socket`
- If multiple IINA instances are running, only the first one responds