### PR TITLE
feat: add IINA auto-pause support via mpv IPC socket

### DIFF
--- a/BGMApp/BGMApp.xcodeproj/project.pbxproj
+++ b/BGMApp/BGMApp.xcodeproj/project.pbxproj
@@ -91,6 +91,9 @@
 		1C8D830520423E1C00A838F2 /* BGMSwinsian.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D8302204238DB00A838F2 /* BGMSwinsian.m */; };
 		1C8D830620423E2400A838F2 /* BGMSwinsian.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D8302204238DB00A838F2 /* BGMSwinsian.m */; };
 		1C8D830B2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D830A2042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMGooglePlayMusicDesktopPlayer.m"; }; };
+		36D6EE4CFE6ACFCB3FDB5E62 /* BGIINA.m in Sources */ = {isa = PBXBuildFile; fileRef = 63C2879EFFF7D8F3FC1140AA /* BGIINA.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGIINA.m"; }; };
+		89BAD0EFE52C3B793228D0E9 /* BGIINA.m in Sources */ = {isa = PBXBuildFile; fileRef = 63C2879EFFF7D8F3FC1140AA /* BGIINA.m */; };
+		562EBED289DCDF25B8D0E38E /* BGIINA.m in Sources */ = {isa = PBXBuildFile; fileRef = 63C2879EFFF7D8F3FC1140AA /* BGIINA.m */; };
 		1C8D830C2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D830A2042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.m */; };
 		1C8D830E2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js in Resources */ = {isa = PBXBuildFile; fileRef = 1C8D830D2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js */; };
 		1C8D830F2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js in Resources */ = {isa = PBXBuildFile; fileRef = 1C8D830D2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js */; };
@@ -345,6 +348,8 @@
 		1C8D8303204238DB00A838F2 /* BGMSwinsian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGMSwinsian.h; path = "Music Players/BGMSwinsian.h"; sourceTree = "<group>"; };
 		1C8D83092042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGMGooglePlayMusicDesktopPlayer.h; path = "Music Players/BGMGooglePlayMusicDesktopPlayer.h"; sourceTree = "<group>"; };
 		1C8D830A2042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BGMGooglePlayMusicDesktopPlayer.m; path = "Music Players/BGMGooglePlayMusicDesktopPlayer.m"; sourceTree = "<group>"; };
+		4A419E5A61212063F7D26408 /* BGIINA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGIINA.h; path = "Music Players/BGIINA.h"; sourceTree = "<group>"; };
+		63C2879EFFF7D8F3FC1140AA /* BGIINA.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BGIINA.m; path = "Music Players/BGIINA.m"; sourceTree = "<group>"; };
 		1C8D830D2042F25C00A838F2 /* GooglePlayMusicDesktopPlayer.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = GooglePlayMusicDesktopPlayer.js; path = "Music Players/GooglePlayMusicDesktopPlayer.js"; sourceTree = "<group>"; };
 		1C9258452090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BGMGooglePlayMusicDesktopPlayerConnection.h; path = "Music Players/BGMGooglePlayMusicDesktopPlayerConnection.h"; sourceTree = "<group>"; };
 		1C9258462090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BGMGooglePlayMusicDesktopPlayerConnection.m; path = "Music Players/BGMGooglePlayMusicDesktopPlayerConnection.m"; sourceTree = "<group>"; };
@@ -598,6 +603,8 @@
 				27F7D48F1D2483B100821C4B /* BGMDecibel.m */,
 				1C8D83092042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.h */,
 				1C8D830A2042DE9500A838F2 /* BGMGooglePlayMusicDesktopPlayer.m */,
+				4A419E5A61212063F7D26408 /* BGIINA.h */,
+				63C2879EFFF7D8F3FC1140AA /* BGIINA.m */,
 				1C9258452090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.h */,
 				1C9258462090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.m */,
 				1C2336DB1BEAB73F004C1C4E /* BGMiTunes.h */,
@@ -1121,6 +1128,7 @@
 				1CD410D41F9EDDAD0070A094 /* BGMAppVolumesController.mm in Sources */,
 				1C1962E41BC94E15008A4DF7 /* CARingBuffer.cpp in Sources */,
 				1C8D830B2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */,
+				36D6EE4CFE6ACFCB3FDB5E62 /* BGIINA.m in Sources */,
 				273F10DF1CC3D0B900C1C6DA /* BGMVOX.m in Sources */,
 				1CC1DF811BE5068A00FB8FE4 /* CACFArray.cpp in Sources */,
 				279F48771DD6D73A00768A85 /* BGMHermes.m in Sources */,
@@ -1182,6 +1190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1C8104B022AD082E00B35517 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */,
+				562EBED289DCDF25B8D0E38E /* BGIINA.m in Sources */,
 				1C8D830520423E1C00A838F2 /* BGMSwinsian.m in Sources */,
 				1CE03A58239B56740036908D /* BGMDebugLoggingMenuItem.m in Sources */,
 				1CACCF3A1F334447007F86CA /* BGMBackgroundMusicDevice.cpp in Sources */,
@@ -1283,6 +1292,7 @@
 				1C227C0B1FA4C48200A95B6D /* BGMAppVolumes.m in Sources */,
 				1CACCF3B1F334450007F86CA /* BGMBackgroundMusicDevice.cpp in Sources */,
 				1C8D830C2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */,
+				89BAD0EFE52C3B793228D0E9 /* BGIINA.m in Sources */,
 				1C3D36741ED90E8600F98E66 /* BGMDeviceControlsList.cpp in Sources */,
 				27FB8C301DE4758A0084DB9D /* BGMPlayThrough.cpp in Sources */,
 				27FB8C311DE4758A0084DB9D /* BGM_Utils.cpp in Sources */,

--- a/BGMApp/BGMApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/BGMApp/BGMApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+</Workspace>

--- a/BGMApp/BGMApp/Music Players/BGIINA.h
+++ b/BGMApp/BGMApp/Music Players/BGIINA.h
@@ -1,0 +1,33 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGIINA.h
+//  BGMApp
+//
+//  Copyright © 2024 Background Music contributors
+//
+//  IINA player support. Controls playback via mpv IPC socket.
+//  Requires user to configure ~/.config/mpv/mpv.conf with:
+//    input-ipc-server=/tmp/iina-mpv-socket
+//
+
+// Superclass/Protocol Import
+#import "BGMMusicPlayer.h"
+
+
+@interface BGIINA : BGMMusicPlayerBase<BGMMusicPlayer>
+
+@end

--- a/BGMApp/BGMApp/Music Players/BGIINA.m
+++ b/BGMApp/BGMApp/Music Players/BGIINA.m
@@ -1,0 +1,332 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGIINA.m
+//  BGMApp
+//
+//  Copyright © 2024 Background Music contributors
+//
+//  IINA player support. Controls playback via mpv IPC socket.
+//
+//  Prerequisite: User must configure ~/.config/mpv/mpv.conf with:
+//    input-ipc-server=/tmp/iina-mpv-socket
+//
+//  Alternative socket paths supported:
+//    - /tmp/iina-mpv-socket (preferred)
+//    - /tmp/mpv-socket (mpv default)
+//
+//  IINA is based on mpv and supports controlling playback via
+//  Unix domain socket using JSON IPC commands.
+//  Reference: https://mpv.io/manual/stable/#json-ipc
+//
+
+// Self Include
+#import "BGIINA.h"
+
+// Local Includes
+#import "BGMAppWatcher.h"
+
+// PublicUtility Includes
+#import "CADebugMacros.h"
+
+// System Includes
+#import <Cocoa/Cocoa.h>
+#import <sys/socket.h>
+#import <sys/un.h>
+#import <sys/stat.h>
+#import <unistd.h>
+#import <sys/ucred.h>
+
+
+// mpv IPC socket paths to check (in priority order)
+// 1. User-configured path in /tmp
+// 2. Default mpv socket location
+// 3. IINA-specific socket location
+static NSString* const kIINAMPVSocketPaths[] = {
+    @"/tmp/iina-mpv-socket",
+    @"/tmp/mpv-socket",
+};
+static const NSUInteger kIINAMPVSocketPathCount = sizeof(kIINAMPVSocketPaths) / sizeof(kIINAMPVSocketPaths[0]);
+
+// Socket timeout in seconds
+static const NSTimeInterval kSocketTimeout = 5.0;
+
+// Cached socket path (nil until first successful connection)
+static NSString* _Nullable cachedSocketPath = nil;
+
+
+#pragma clang assume_nonnull begin
+
+@implementation BGIINA {
+    BGMAppWatcher* appWatcher;
+    BOOL _running;
+}
+
+- (instancetype) init {
+    if ((self = [super initWithMusicPlayerID:[BGMMusicPlayerBase makeID:@"41FE4E09-85FF-40F3-B336-5C973F4CCD86"]
+                                        name:@"IINA"
+                                    bundleID:@"com.colliderli.iina"])) {
+        BGIINA* __weak weakSelf = self;
+        appWatcher = [[BGMAppWatcher alloc]
+            initWithBundleID:@"com.colliderli.iina"
+                 appLaunched:^{
+                     BGIINA* strongSelf = weakSelf;
+                     if (strongSelf) {
+                         strongSelf->_running = YES;
+                         DebugMsg("BGIINA: IINA launched");
+                     }
+                 }
+               appTerminated:^{
+                   BGIINA* strongSelf = weakSelf;
+                   if (strongSelf) {
+                       strongSelf->_running = NO;
+                       DebugMsg("BGIINA: IINA terminated");
+                   }
+               }];
+
+        NSArray<NSRunningApplication*>* running =
+            [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.colliderli.iina"];
+        _running = (running.count > 0);
+    }
+    return self;
+}
+
+#pragma mark BGMMusicPlayer
+
+- (BOOL) isRunning {
+    NSArray<NSRunningApplication*>* running =
+        [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.colliderli.iina"];
+    return running.count > 0;
+}
+
+- (BOOL) isPlaying {
+    if (!self.running) return NO;
+
+    // Query playback state via mpv IPC
+    // get_property pause returns true when paused
+    NSDictionary* response = [self sendMPVGetProperty:@"pause"];
+    if (response && [response[@"error"] isEqualToString:@"success"]) {
+        // data: false means not paused (playing)
+        return [response[@"data"] boolValue] == NO;
+    }
+    return NO;
+}
+
+- (BOOL) isPaused {
+    if (!self.running) return NO;
+
+    NSDictionary* response = [self sendMPVGetProperty:@"pause"];
+    if (response && [response[@"error"] isEqualToString:@"success"]) {
+        // data: true means paused
+        return [response[@"data"] boolValue] == YES;
+    }
+    return NO;
+}
+
+- (BOOL) pause {
+    if (!self.running) {
+        DebugMsg("BGIINA::pause: IINA is not running");
+        return NO;
+    }
+
+    // Check if playing first to avoid redundant pause
+    BOOL wasPlaying = self.playing;
+
+    if (wasPlaying) {
+        DebugMsg("BGIINA::pause: Pausing IINA via mpv IPC");
+        [self sendMPVSetProperty:@"pause" value:@YES];
+    }
+
+    return wasPlaying;
+}
+
+- (BOOL) unpause {
+    if (!self.running) {
+        DebugMsg("BGIINA::unpause: IINA is not running");
+        return NO;
+    }
+
+    // Check if paused first to avoid redundant unpause
+    BOOL wasPaused = self.paused;
+
+    if (wasPaused) {
+        DebugMsg("BGIINA::unpause: Resuming IINA via mpv IPC");
+        [self sendMPVSetProperty:@"pause" value:@NO];
+    }
+
+    return wasPaused;
+}
+
+#pragma mark mpv IPC - High-level Interface
+
+- (NSDictionary* __nullable) sendMPVGetProperty:(NSString*)property {
+    NSData* response = [self sendMPVCommand:@[@"get_property", property]];
+    if (response) {
+        return [self parseResponse:response];
+    }
+    return nil;
+}
+
+- (BOOL) sendMPVSetProperty:(NSString*)property value:(id)value {
+    NSData* response = [self sendMPVCommand:@[@"set_property", property, value]];
+    if (response) {
+        NSDictionary* json = [self parseResponse:response];
+        return json && [json[@"error"] isEqualToString:@"success"];
+    }
+    return NO;
+}
+
+- (NSDictionary* __nullable) parseResponse:(NSData*)data {
+    NSError* error = nil;
+    NSDictionary* json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    if (error) {
+        DebugMsg("BGIINA::parseResponse: JSON parse failed: %s", error.localizedDescription.UTF8String);
+        return nil;
+    }
+    return json;
+}
+
+#pragma mark mpv IPC - Low-level Interface
+
+- (BOOL) isValidSocket:(NSString*)path {
+    // Use lstat instead of stat to avoid following symlinks
+    struct stat socketStat;
+    if (lstat([path UTF8String], &socketStat) != 0) {
+        return NO;
+    }
+
+    // Verify it's a socket file
+    if (!S_ISSOCK(socketStat.st_mode)) {
+        return NO;
+    }
+
+    // Verify owner is current user
+    uid_t currentUid = getuid();
+    if (socketStat.st_uid != currentUid) {
+        DebugMsg("BGIINA::isValidSocket: Socket owner mismatch for %s (expected=%d, actual=%d)",
+                 path.UTF8String, currentUid, socketStat.st_uid);
+        return NO;
+    }
+
+    // Note: Do not check socket permissions because mpv creates sockets with 755 by default.
+    // Security relies on LOCAL_PEERCRED verification after connect.
+
+    return YES;
+}
+
+- (NSString* __nullable) findSocketPath {
+    // Return cached path if still valid
+    if (cachedSocketPath != nil) {
+        NSString* path = cachedSocketPath;
+        if ([self isValidSocket:path]) {
+            return path;
+        }
+    }
+
+    // Search for valid socket in priority order
+    for (NSUInteger i = 0; i < kIINAMPVSocketPathCount; i++) {
+        NSString* path = kIINAMPVSocketPaths[i];
+        if ([self isValidSocket:path]) {
+            cachedSocketPath = path;
+            DebugMsg("BGIINA::findSocketPath: Found valid socket at %s", path.UTF8String);
+            return path;
+        }
+    }
+
+    DebugMsg("BGIINA::findSocketPath: No valid socket found");
+    return nil;
+}
+
+- (NSData* __nullable) sendMPVCommand:(NSArray*)command {
+    // Find valid socket path
+    NSString* socketPath = [self findSocketPath];
+    if (!socketPath) {
+        DebugMsg("BGIINA::sendMPVCommand: No valid mpv IPC socket found");
+        return nil;
+    }
+
+    // Create Unix domain socket connection
+    int sock = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sock < 0) {
+        DebugMsg("BGIINA::sendMPVCommand: Failed to create socket");
+        return nil;
+    }
+
+    // Set socket timeout
+    struct timeval tv;
+    tv.tv_sec = (long)kSocketTimeout;
+    tv.tv_usec = 0;
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    // Set socket address
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, [socketPath UTF8String], sizeof(addr.sun_path) - 1);
+
+    // Connect to socket
+    if (connect(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        DebugMsg("BGIINA::sendMPVCommand: Failed to connect to socket");
+        close(sock);
+        return nil;
+    }
+
+    // Verify peer credentials
+    struct xucred peerCred;
+    socklen_t credLen = sizeof(peerCred);
+    if (getsockopt(sock, 0, LOCAL_PEERCRED, &peerCred, &credLen) == 0) {
+        uid_t currentUid = getuid();
+        if (peerCred.cr_uid != currentUid) {
+            DebugMsg("BGIINA::sendMPVCommand: Peer credential verification failed (expected=%d, actual=%d)",
+                     currentUid, peerCred.cr_uid);
+            close(sock);
+            return nil;
+        }
+    }
+
+    // Build JSON IPC command
+    // Format: {"command": [cmd, arg1, arg2, ...]}
+    NSDictionary* ipcCommand = @{@"command": command};
+    NSData* jsonData = [NSJSONSerialization dataWithJSONObject:ipcCommand options:0 error:nil];
+    NSString* jsonCommand = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    jsonCommand = [jsonCommand stringByAppendingString:@"\n"];
+
+    // Send command
+    ssize_t sent = send(sock, [jsonCommand UTF8String], [jsonCommand length], 0);
+    if (sent < 0) {
+        DebugMsg("BGIINA::sendMPVCommand: Failed to send command");
+        close(sock);
+        return nil;
+    }
+
+    // Receive response
+    char buffer[4096];
+    ssize_t received = recv(sock, buffer, sizeof(buffer) - 1, 0);
+    close(sock);
+
+    if (received <= 0) {
+        DebugMsg("BGIINA::sendMPVCommand: No response received");
+        return nil;
+    }
+
+    buffer[received] = '\0';
+    return [NSData dataWithBytes:buffer length:received];
+}
+
+@end
+
+#pragma clang assume_nonnull end

--- a/BGMApp/BGMApp/Music Players/BGMMusicPlayers.mm
+++ b/BGMApp/BGMApp/Music Players/BGMMusicPlayers.mm
@@ -36,6 +36,7 @@
 #import "BGMSwinsian.h"
 #import "BGMMusic.h"
 #import "BGMGooglePlayMusicDesktopPlayer.h"
+#import "BGIINA.h"
 
 
 #pragma clang assume_nonnull begin
@@ -58,7 +59,8 @@
                                                    [BGMDecibel class],
                                                    [BGMHermes class],
                                                    [BGMSwinsian class],
-                                                   [BGMMusic class] ];
+                                                   [BGMMusic class],
+                                                   [BGIINA class] ];
 
     // We only support Google Play Music Desktop Player on macOS 10.10 and higher.
     if (@available(macOS 10.10, *)) {


### PR DESCRIPTION
## Add IINA Auto-Pause Support

### Summary
Add auto-pause support for [IINA](https://iina.io/), a modern macOS media player based on mpv.

### Background
IINA is one of the most popular open-source media players on macOS. Unlike Spotify/iTunes/VLC, IINA does not support AppleScript or Scripting Bridge, which are the standard mechanisms used by Background Music to control music players.

After extensive research, we discovered that IINA is built on top of **mpv** and supports mpv's **JSON IPC protocol** via Unix domain socket.

### Implementation
- Add `BGIINA` music player class implementing `BGMMusicPlayer` protocol
- Control IINA playback via mpv JSON IPC protocol over Unix domain socket
- Support multiple socket paths: `/tmp/iina-mpv-socket`, `/tmp/mpv-socket`
- Cache successful socket path for performance

### Security Measures
- Use `lstat` to prevent symlink attacks
- Verify socket file owner matches current user
- Verify peer credentials via `LOCAL_PEERCRED` after connection
- Set socket timeout (5 seconds) to prevent blocking

### Commands Used
- `get_property "pause"` - Query playback state
- `set_property "pause", true/false` - Control playback

### Prerequisite
User must configure `~/.config/mpv/mpv.conf` with:
```
input-ipc-server=/tmp/iina-mpv-socket
```
Then restart IINA for the configuration to take effect.

### Files Changed
- `BGMApp/BGMApp/Music Players/BGIINA.h` (new)
- `BGMApp/BGMApp/Music Players/BGIINA.m` (new)
- `BGMApp/BGMApp/Music Players/BGMMusicPlayers.mm` (modified - add IINA import and registration)
- `BGMApp/BGMApp.xcodeproj/project.pbxproj` (modified - add new files)

### Testing
- **Tested on**: macOS 15.7.5 (Intel x86_64)
- **IINA version**: 1.4.3
- **Test scenarios**:
  1. IINA playing video + browser audio → IINA pauses ✓
  2. Browser audio stops → IINA resumes ✓
  3. IINA manually paused → does not auto-resume ✓
  4. IINA closed → no errors ✓
  5. Socket not configured → graceful fallback ✓