### PR TITLE
[Feature] Add option to duck music player volume instead of pausing (#541)

### DIFF
--- a/BGMApp/BGMApp/BGMAutoPauseMenuItem.m
+++ b/BGMApp/BGMApp/BGMAutoPauseMenuItem.m
@@ -30,7 +30,8 @@
 
 #pragma clang assume_nonnull begin
 
-static NSString* const kMenuItemTitleFormat = @"Auto-pause %@";
+static NSString* const kMenuItemTitleFormatPause = @"Auto-pause %@";
+static NSString* const kMenuItemTitleFormatDuck = @"Auto-duck %@";
 static NSString* const kMenuItemDisabledToolTipFormat = @"%@ doesn't appear to be running.";
 
 // Wait time to disable/enable the auto-pause menu item, in seconds.
@@ -123,7 +124,8 @@ static SInt64 const kMenuItemUpdateWaitTime = 1;
 - (void) updateMenuItemTitleWithHighlight:(BOOL)highlight {
     // Set the title of the Auto-pause Music menu item, including the name of the selected music player.
     NSString* musicPlayerName = musicPlayers.selectedMusicPlayer.name;
-    menuItem.title = [NSString stringWithFormat:kMenuItemTitleFormat, musicPlayerName];
+    NSString* titleFormat = userDefaults.autoDuckMusic ? kMenuItemTitleFormatDuck : kMenuItemTitleFormatPause;
+    menuItem.title = [NSString stringWithFormat:titleFormat, musicPlayerName];
     
     // Make the Auto-pause Music menu item appear disabled if the application is not running.
     //

--- a/BGMApp/BGMApp/BGMAutoPauseMusic.mm
+++ b/BGMApp/BGMApp/BGMAutoPauseMusic.mm
@@ -24,8 +24,11 @@
 #import "BGMAutoPauseMusic.h"
 
 // Local Includes
-#include "BGM_Types.h"
+#import "BGM_Types.h"
 #import "BGMMusicPlayer.h"
+#import "CACFArray.h"
+#import "CACFDictionary.h"
+#import "CACFString.h"
 
 // STL Includes
 #import <algorithm>  // std::max, std::min
@@ -54,6 +57,12 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     // True if BGMApp has paused musicPlayer and hasn't unpaused it yet. (Will be out of sync with the music player app if the
     // user has unpaused it themselves.)
     BOOL wePaused;
+    // True if BGMApp has ducked the musicPlayer and hasn't unducked it yet.
+    BOOL weDucked;
+    // The original volume before ducking.
+    int originalVolume;
+    // The ducked volume we set.
+    int duckedVolume;
     // The times, in absolute time, that the BGMDevice last changed its audible state to silent...
     UInt64 wentSilent;
     // ...and to audible.
@@ -68,6 +77,9 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
         
         enabled = NO;
         wePaused = NO;
+        weDucked = NO;
+        originalVolume = kAppRelativeVolumeMaxRawValue;
+        duckedVolume = kAppRelativeVolumeMaxRawValue;
         
         dispatch_queue_attr_t attr;
 
@@ -84,6 +96,15 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
         listenerQueue = dispatch_queue_create("com.bearisdriving.BGM.AutoPauseMusic.Listener", attr);
         pauseUnpauseMusicQueue = dispatch_queue_create("com.bearisdriving.BGM.AutoPauseMusic.PauseUnpauseMusic", attr);
         
+        [userDefaults addObserver:self
+                       forKeyPath:@"autoDuckMusic"
+                          options:NSKeyValueObservingOptionNew
+                          context:nil];
+        [musicPlayers addObserver:self
+                       forKeyPath:@"selectedMusicPlayer"
+                          options:NSKeyValueObservingOptionNew
+                          context:nil];
+        
         [self initListenerBlock];
     }
     
@@ -92,6 +113,14 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
 
 - (void) dealloc {
     [self disable];
+    try {
+        [userDefaults removeObserver:self forKeyPath:@"autoDuckMusic" context:nil];
+    } catch (const std::exception& e) {
+    }
+    try {
+        [musicPlayers removeObserver:self forKeyPath:@"selectedMusicPlayer" context:nil];
+    } catch (const std::exception& e) {
+    }
 }
 
 - (void) initListenerBlock {
@@ -120,8 +149,9 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                 } else if (audibleState == kBGMDeviceIsSilentExceptMusic) {
                     // If we pause the music player and then the user unpauses it before the other audio stops, we need to set
                     // wePaused to false at some point before the other audio starts again so we know we should pause
-                    DebugMsg("BGMAutoPauseMusic: Device is silent except music, resetting wePaused flag");
+                    DebugMsg("BGMAutoPauseMusic: Device is silent except music, resetting wePaused/weDucked flags");
                     wePaused = NO;
+                    weDucked = NO;
                 }
                 // TODO: Add a fourth audible state, something like "AudibleAndMusicPlaying", and check it here to
                 //       handle the user unpausing and then repausing music while also playing other audio?
@@ -141,35 +171,43 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     
     UInt64 pauseDelayMS = userDefaults.pauseDelayMS;
     
-    // If pause delay is 0, pause immediately (no delay)
+    // If pause delay is 0, pause/duck immediately (no delay)
     if (pauseDelayMS == 0) {
-        DebugMsg("BGMAutoPauseMusic::queuePauseBlock: Pause delay is 0, pausing immediately");
+        DebugMsg("BGMAutoPauseMusic::queuePauseBlock: Pause/duck delay is 0, pausing/ducking immediately");
         
-        // Pause immediately if device is audible and we haven't already paused
-        if (!wePaused && ([self deviceAudibleState] == kBGMDeviceIsAudible)) {
-            wePaused = ([musicPlayers.selectedMusicPlayer pause] || wePaused);
+        // Pause/duck immediately if device is audible and we haven't already paused/ducked
+        if (!wePaused && !weDucked && ([self deviceAudibleState] == kBGMDeviceIsAudible)) {
+            if (userDefaults.autoDuckMusic) {
+                [self duckMusicPlayer];
+            } else {
+                wePaused = ([musicPlayers.selectedMusicPlayer pause] || wePaused);
+            }
         }
         return;
     }
     
     UInt64 pauseDelayNSec = pauseDelayMS * NSEC_PER_MSEC;
     
-    DebugMsg("BGMAutoPauseMusic::queuePauseBlock: Dispatching pause block at %llu", now);
+    DebugMsg("BGMAutoPauseMusic::queuePauseBlock: Dispatching pause/duck block at %llu", now);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, pauseDelayNSec),
                    pauseUnpauseMusicQueue,
                    ^{
                        BOOL stillAudible = ([self deviceAudibleState] == kBGMDeviceIsAudible);
                        
-                       DebugMsg("BGMAutoPauseMusic::queuePauseBlock: Running pause block dispatched at %llu.%s wentAudible=%llu",
+                       DebugMsg("BGMAutoPauseMusic::queuePauseBlock: Running pause/duck block dispatched at %llu.%s wentAudible=%llu",
                                 startedPauseDelay,
-                                stillAudible ? "" : " Not pausing because the device isn't audible.",
+                                stillAudible ? "" : " Not pausing/ducking because the device isn't audible.",
                                 wentAudible);
                        
-                       // Pause if this is the most recent pause block and the device is still audible, which means the audible
-                       // state hasn't changed since this block was queued. Also set wePaused to true if the player wasn't
-                       // already paused.
-                       if (!wePaused && (startedPauseDelay == wentAudible) && stillAudible) {
-                           wePaused = ([musicPlayers.selectedMusicPlayer pause] || wePaused);
+                       // Pause/duck if this is the most recent pause block and the device is still audible, which means the audible
+                       // state hasn't changed since this block was queued. Also set wePaused/weDucked to true if the player wasn't
+                       // already paused/ducked.
+                       if (!wePaused && !weDucked && (startedPauseDelay == wentAudible) && stillAudible) {
+                           if (userDefaults.autoDuckMusic) {
+                               [self duckMusicPlayer];
+                           } else {
+                               wePaused = ([musicPlayers.selectedMusicPlayer pause] || wePaused);
+                           }
                        }
                    });
 }
@@ -182,29 +220,30 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     // Get user-configurable max delay
     UInt64 maxUnpauseDelayMS = userDefaults.maxUnpauseDelayMS;
     
-    // If max unpause delay is 0, unpause immediately (no delay)
+    // If max unpause delay is 0, unpause/unduck immediately (no delay)
     if (maxUnpauseDelayMS == 0) {
-        DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Max unpause delay is 0, unpausing immediately");
+        DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Max unpause/unduck delay is 0, unpausing/unducking immediately");
         
-        // Unpause immediately if we were the one who paused and device is still silent
         BGMDeviceAudibleState currentState = [self deviceAudibleState];
-        DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Immediate unpause - wePaused=%s, currentState=%s", 
+        DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Immediate unpause/unduck - wePaused=%s, weDucked=%s, currentState=%s", 
                  wePaused ? "YES" : "NO", 
+                 weDucked ? "YES" : "NO",
                  currentState == kBGMDeviceIsSilent ? "Silent" : 
                  (currentState == kBGMDeviceIsAudible ? "Audible" : "SilentExceptMusic"));
         
-        if (wePaused && (currentState == kBGMDeviceIsSilent)) {
-            wePaused = NO;
-            [musicPlayers.selectedMusicPlayer unpause];
+        if (currentState == kBGMDeviceIsSilent) {
+            if (wePaused) {
+                wePaused = NO;
+                [musicPlayers.selectedMusicPlayer unpause];
+            } else if (weDucked) {
+                [self unduckMusicPlayer];
+            }
         }
         return;
     }
     
-    // Unpause sooner if we've only been paused for a short time. This is so a notification sound causing an auto-pause is
+    // Unpause sooner if we've only been paused/ducked for a short time. This is so a notification sound causing an auto-pause/duck is
     // less of an interruption.
-    //
-    // TODO: Fading in and out would make short pauses a lot less jarring because, if they were short enough, we wouldn't
-    //       actually pause the music player. So you'd hear a dip in the music's volume rather than a gap.
     UInt64 unpauseDelayNsec =
         static_cast<UInt64>(static_cast<Float64>(wentSilent - wentAudible) *
                             kUnpauseDelayWeightingFactor);
@@ -220,7 +259,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     unpauseDelayNsec = std::min(maxUnpauseDelayNSec, unpauseDelayNsec);
     unpauseDelayNsec = std::max(minUnpauseDelayNSec, unpauseDelayNsec);
     
-    DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Dispatched unpause block at %llu. unpauseDelayNsec=%llu",
+    DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Dispatched unpause/unduck block at %llu. unpauseDelayNsec=%llu",
              now,
              unpauseDelayNsec);
     
@@ -231,20 +270,23 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                        BOOL stillSilent = (currentState == kBGMDeviceIsSilent);
                        BOOL isLatestUnpause = (startedUnpauseDelay == wentSilent);
                        
-                       DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Running unpause block dispatched at %llu. wePaused=%s, isLatest=%s, currentState=%s, wentSilent=%llu",
+                       DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Running unpause/unduck block dispatched at %llu. wePaused=%s, weDucked=%s, isLatest=%s, currentState=%s, wentSilent=%llu",
                                 startedUnpauseDelay,
                                 wePaused ? "YES" : "NO",
+                                weDucked ? "YES" : "NO",
                                 isLatestUnpause ? "YES" : "NO",
                                 currentState == kBGMDeviceIsSilent ? "Silent" : 
                                 (currentState == kBGMDeviceIsAudible ? "Audible" : "SilentExceptMusic"),
                                 wentSilent);
                        
-                       // Unpause if we were the one who paused. Also check that this is the most recent unpause block and the
-                       // device is still silent, which means the audible state hasn't changed since this block was queued.
-                       if (wePaused && isLatestUnpause && stillSilent) {
-                           DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Unpausing music player");
-                           wePaused = NO;
-                           [musicPlayers.selectedMusicPlayer unpause];
+                       if (isLatestUnpause && stillSilent) {
+                           if (wePaused) {
+                               DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Unpausing music player");
+                               wePaused = NO;
+                               [musicPlayers.selectedMusicPlayer unpause];
+                           } else if (weDucked) {
+                               [self unduckMusicPlayer];
+                           }
                        }
                    });
 }
@@ -260,6 +302,137 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     if (enabled) {
         [audioDevices bgmDevice].RemovePropertyListenerBlock(kBGMAudibleStateAddress, listenerQueue, listenerBlock);
         enabled = NO;
+    }
+}
+
+- (void) observeValueForKeyPath:(NSString* __nullable)keyPath
+                       ofObject:(id __nullable)object
+                         change:(NSDictionary* __nullable)change
+                        context:(void* __nullable)context
+{
+    #pragma unused (object, change, context)
+    if ([keyPath isEqualToString:@"autoDuckMusic"]) {
+        if (wePaused || weDucked) {
+            dispatch_async(pauseUnpauseMusicQueue, ^{
+                BGMDeviceAudibleState state = [self deviceAudibleState];
+                if (state == kBGMDeviceIsAudible) {
+                    if (userDefaults.autoDuckMusic && wePaused) {
+                        // Transition from paused to ducked:
+                        // 1. Unpause
+                        [musicPlayers.selectedMusicPlayer unpause];
+                        wePaused = NO;
+                        // 2. Duck
+                        [self duckMusicPlayer];
+                    } else if (!userDefaults.autoDuckMusic && weDucked) {
+                        // Transition from ducked to paused:
+                        // 1. Unduck
+                        [self unduckMusicPlayer];
+                        // 2. Pause
+                        wePaused = ([musicPlayers.selectedMusicPlayer pause] || wePaused);
+                    }
+                }
+            });
+        }
+    } else if ([keyPath isEqualToString:@"selectedMusicPlayer"]) {
+        wePaused = NO;
+        weDucked = NO;
+    }
+}
+
+- (void) duckMusicPlayer {
+    id<BGMMusicPlayer> player = musicPlayers.selectedMusicPlayer;
+    if (!player.isRunning || !player.isPlaying) {
+        return;
+    }
+    
+    originalVolume = [self getMusicPlayerVolume];
+    
+    static float const kDuckingFactor = 0.3f;
+    duckedVolume = (int)(static_cast<float>(originalVolume) * kDuckingFactor);
+    if (duckedVolume >= originalVolume && originalVolume > 0) {
+        duckedVolume = originalVolume - 1;
+    }
+    
+    DebugMsg("BGMAutoPauseMusic::duckMusicPlayer: originalVolume=%d, duckedVolume=%d", originalVolume, duckedVolume);
+    
+    [self setMusicPlayerVolume:duckedVolume];
+    weDucked = YES;
+}
+
+- (void) unduckMusicPlayer {
+    if (!weDucked) {
+        return;
+    }
+    
+    int currentVolume = [self getMusicPlayerVolume];
+    DebugMsg("BGMAutoPauseMusic::unduckMusicPlayer: currentVolume=%d, expectedDuckedVolume=%d, originalVolume=%d",
+             currentVolume, duckedVolume, originalVolume);
+             
+    if (currentVolume == duckedVolume) {
+        DebugMsg("BGMAutoPauseMusic::unduckMusicPlayer: Restoring volume to originalVolume=%d", originalVolume);
+        [self setMusicPlayerVolume:originalVolume];
+    } else {
+        DebugMsg("BGMAutoPauseMusic::unduckMusicPlayer: Volume was changed manually while ducked. Keeping currentVolume=%d", currentVolume);
+    }
+    
+    weDucked = NO;
+}
+
+- (int) getMusicPlayerVolume {
+    id<BGMMusicPlayer> player = musicPlayers.selectedMusicPlayer;
+    NSString* playerBundleID = player.bundleID;
+    pid_t playerPid = player.pid ? [player.pid intValue] : -1;
+    
+    if (playerPid == -1 && playerBundleID != nil) {
+        NSArray<NSRunningApplication*>* apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:playerBundleID];
+        if (apps.count > 0) {
+            playerPid = apps.firstObject.processIdentifier;
+        }
+    }
+
+    try {
+        CACFArray volumes([audioDevices bgmDevice].GetAppVolumes(), false);
+        for (UInt32 i = 0; i < volumes.GetNumberItems(); i++) {
+            CACFDictionary appVolume(false);
+            volumes.GetCACFDictionary(i, appVolume);
+
+            CACFString bundleID;
+            bundleID.DontAllowRelease();
+            appVolume.GetCACFString(CFSTR(kBGMAppVolumesKey_BundleID), bundleID);
+
+            pid_t pid;
+            appVolume.GetSInt32(CFSTR(kBGMAppVolumesKey_ProcessID), pid);
+
+            if ((playerPid != -1 && playerPid == pid) ||
+                (playerBundleID != nil && [playerBundleID isEqualToString:(__bridge NSString*)bundleID.GetCFString()])) {
+                int volume = -1;
+                appVolume.GetSInt32(CFSTR(kBGMAppVolumesKey_RelativeVolume), volume);
+                return volume;
+            }
+        }
+    } catch (const std::exception& e) {
+        NSLog(@"BGMAutoPauseMusic::getMusicPlayerVolume error: %s", e.what());
+    }
+
+    return kAppRelativeVolumeMaxRawValue;
+}
+
+- (void) setMusicPlayerVolume:(int)volume {
+    id<BGMMusicPlayer> player = musicPlayers.selectedMusicPlayer;
+    NSString* playerBundleID = player.bundleID;
+    pid_t playerPid = player.pid ? [player.pid intValue] : -1;
+    
+    if (playerPid == -1 && playerBundleID != nil) {
+        NSArray<NSRunningApplication*>* apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:playerBundleID];
+        if (apps.count > 0) {
+            playerPid = apps.firstObject.processIdentifier;
+        }
+    }
+    
+    try {
+        [audioDevices bgmDevice].SetAppVolume(volume, playerPid, (__bridge CFStringRef)playerBundleID);
+    } catch (const std::exception& e) {
+        NSLog(@"BGMAutoPauseMusic::setMusicPlayerVolume error: %s", e.what());
     }
 }
 

--- a/BGMApp/BGMApp/BGMAutoPauseMusic.mm
+++ b/BGMApp/BGMApp/BGMAutoPauseMusic.mm
@@ -26,6 +26,7 @@
 // Local Includes
 #import "BGM_Types.h"
 #import "BGMMusicPlayer.h"
+#import "BGM_Utils.h"
 #import "CACFArray.h"
 #import "CACFDictionary.h"
 #import "CACFString.h"
@@ -257,8 +258,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
         return;
     }
     
-    // Unpause sooner if we've only been paused/ducked for a short time. This is so a notification sound causing an auto-pause/duck is
-    // less of an interruption.
+    // Unpause sooner if we've only been paused/ducked for a short time. This is so a notification sound causing an auto-pause/duck is less of an interruption. See issue #311 for the longer fade-out/fade-in transition idea.
     UInt64 unpauseDelayNsec =
         static_cast<UInt64>(static_cast<Float64>(wentSilent - wentAudible) *
                             kUnpauseDelayWeightingFactor);
@@ -294,6 +294,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                                 (currentState == kBGMDeviceIsAudible ? "Audible" : "SilentExceptMusic"),
                                 wentSilent);
                        
+                       // Unpause or unduck if we were the one who paused/ducked. Also check that the device is still silent (or silent-except-music if we ducked), which means the audible state hasn't changed since this block was queued.
                        if (isLatestUnpause && silentEnough) {
                            if (wePaused) {
                                DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Unpausing music player");
@@ -409,6 +410,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     id<BGMMusicPlayer> player = musicPlayers.selectedMusicPlayer;
     NSString* playerBundleID = player.bundleID;
     pid_t playerPid = player.pid ? [player.pid intValue] : -1;
+    __block int volume = 50;
     
     if (playerPid == -1 && playerBundleID != nil) {
         NSArray<NSRunningApplication*>* apps = [NSRunningApplication runningApplicationsWithBundleIdentifier:playerBundleID];
@@ -417,7 +419,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
         }
     }
 
-    try {
+    BGMLogAndSwallowExceptions("BGMAutoPauseMusic::getMusicPlayerVolume", ([&] {
         CACFArray volumes([audioDevices bgmDevice].GetAppVolumes(), false);
         for (UInt32 i = 0; i < volumes.GetNumberItems(); i++) {
             CACFDictionary appVolume(false);
@@ -432,16 +434,13 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
 
             if ((playerPid != -1 && playerPid == pid) ||
                 (playerBundleID != nil && [playerBundleID isEqualToString:(__bridge NSString*)bundleID.GetCFString()])) {
-                int volume = -1;
                 appVolume.GetSInt32(CFSTR(kBGMAppVolumesKey_RelativeVolume), volume);
-                return volume;
+                break;
             }
         }
-    } catch (const std::exception& e) {
-        NSLog(@"BGMAutoPauseMusic::getMusicPlayerVolume error: %s", e.what());
-    }
+    }));
 
-    return 50;
+    return volume;
 }
 
 - (void) setMusicPlayerVolume:(int)volume {
@@ -456,11 +455,9 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
         }
     }
     
-    try {
+    BGMLogAndSwallowExceptions("BGMAutoPauseMusic::setMusicPlayerVolume", ([&] {
         [audioDevices bgmDevice].SetAppVolume(volume, playerPid, (__bridge CFStringRef)playerBundleID);
-    } catch (const std::exception& e) {
-        NSLog(@"BGMAutoPauseMusic::setMusicPlayerVolume error: %s", e.what());
-    }
+    }));
 }
 
 @end

--- a/BGMApp/BGMApp/BGMAutoPauseMusic.mm
+++ b/BGMApp/BGMApp/BGMAutoPauseMusic.mm
@@ -80,8 +80,8 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
         enabled = NO;
         wePaused = NO;
         weDucked = NO;
-        originalVolume = kAppRelativeVolumeMaxRawValue;
-        duckedVolume = kAppRelativeVolumeMaxRawValue;
+        originalVolume = 50;
+        duckedVolume = 50;
         
         dispatch_queue_attr_t attr;
 
@@ -441,7 +441,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
         NSLog(@"BGMAutoPauseMusic::getMusicPlayerVolume error: %s", e.what());
     }
 
-    return kAppRelativeVolumeMaxRawValue;
+    return 50;
 }
 
 - (void) setMusicPlayerVolume:(int)volume {

--- a/BGMApp/BGMApp/BGMAutoPauseMusic.mm
+++ b/BGMApp/BGMApp/BGMAutoPauseMusic.mm
@@ -32,6 +32,8 @@
 
 // STL Includes
 #import <algorithm>  // std::max, std::min
+#include <cmath>
+
 
 // System Includes
 #include <CoreAudio/AudioHardware.h>
@@ -100,6 +102,10 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                        forKeyPath:@"autoDuckMusic"
                           options:NSKeyValueObservingOptionNew
                           context:nil];
+        [userDefaults addObserver:self
+                       forKeyPath:@"autoDuckPercent"
+                          options:NSKeyValueObservingOptionNew
+                          context:nil];
         [musicPlayers addObserver:self
                        forKeyPath:@"selectedMusicPlayer"
                           options:NSKeyValueObservingOptionNew
@@ -118,6 +124,10 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     } catch (const std::exception& e) {
     }
     try {
+        [userDefaults removeObserver:self forKeyPath:@"autoDuckPercent" context:nil];
+    } catch (const std::exception& e) {
+    }
+    try {
         [musicPlayers removeObserver:self forKeyPath:@"selectedMusicPlayer" context:nil];
     } catch (const std::exception& e) {
     }
@@ -132,7 +142,10 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
         // so we have to check them all
         for (int i = 0; i < inNumberAddresses; i++) {
             if (inAddresses[i].mSelector == kAudioDeviceCustomPropertyDeviceAudibleState) {
-                BGMDeviceAudibleState audibleState = [weakSelf deviceAudibleState];
+                BGMAutoPauseMusic* strongSelf = weakSelf;
+                if (!strongSelf) return;
+                
+                BGMDeviceAudibleState audibleState = [strongSelf deviceAudibleState];
                 
 #if DEBUG
                 const char audibleStateStr[5] = CA4CCToCString(audibleState);
@@ -143,18 +156,19 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                 // TODO: We shouldn't assume this block will only get called when BGMDevice's audible state changes. (Even if
                 //       the Core Audio docs did specify that, there's no reason not to be fault tolerant.)
                 if (audibleState == kBGMDeviceIsAudible) {
-                    [weakSelf queuePauseBlock];
+                    [strongSelf queuePauseBlock];
                 } else if (audibleState == kBGMDeviceIsSilent) {
-                    [weakSelf queueUnpauseBlock];
+                    [strongSelf queueUnpauseBlock];
                 } else if (audibleState == kBGMDeviceIsSilentExceptMusic) {
-                    // If we pause the music player and then the user unpauses it before the other audio stops, we need to set
-                    // wePaused to false at some point before the other audio starts again so we know we should pause
-                    DebugMsg("BGMAutoPauseMusic: Device is silent except music, resetting wePaused/weDucked flags");
-                    wePaused = NO;
-                    weDucked = NO;
+                    if (strongSelf->weDucked) {
+                        [strongSelf queueUnpauseBlock];
+                    } else {
+                        // If we pause the music player and then the user unpauses it before the other audio stops, we need to set
+                        // wePaused to false at some point before the other audio starts again so we know we should pause
+                        DebugMsg("BGMAutoPauseMusic: Device is silent except music, resetting wePaused flag");
+                        strongSelf->wePaused = NO;
+                    }
                 }
-                // TODO: Add a fourth audible state, something like "AudibleAndMusicPlaying", and check it here to
-                //       handle the user unpausing and then repausing music while also playing other audio?
             }
         }
     };
@@ -231,7 +245,8 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                  currentState == kBGMDeviceIsSilent ? "Silent" : 
                  (currentState == kBGMDeviceIsAudible ? "Audible" : "SilentExceptMusic"));
         
-        if (currentState == kBGMDeviceIsSilent) {
+        BOOL silentEnough = (currentState == kBGMDeviceIsSilent) || (weDucked && (currentState == kBGMDeviceIsSilentExceptMusic));
+        if (silentEnough) {
             if (wePaused) {
                 wePaused = NO;
                 [musicPlayers.selectedMusicPlayer unpause];
@@ -267,7 +282,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                    pauseUnpauseMusicQueue,
                    ^{
                        BGMDeviceAudibleState currentState = [self deviceAudibleState];
-                       BOOL stillSilent = (currentState == kBGMDeviceIsSilent);
+                       BOOL silentEnough = (currentState == kBGMDeviceIsSilent) || (weDucked && (currentState == kBGMDeviceIsSilentExceptMusic));
                        BOOL isLatestUnpause = (startedUnpauseDelay == wentSilent);
                        
                        DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Running unpause/unduck block dispatched at %llu. wePaused=%s, weDucked=%s, isLatest=%s, currentState=%s, wentSilent=%llu",
@@ -279,7 +294,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                                 (currentState == kBGMDeviceIsAudible ? "Audible" : "SilentExceptMusic"),
                                 wentSilent);
                        
-                       if (isLatestUnpause && stillSilent) {
+                       if (isLatestUnpause && silentEnough) {
                            if (wePaused) {
                                DebugMsg("BGMAutoPauseMusic::queueUnpauseBlock: Unpausing music player");
                                wePaused = NO;
@@ -333,6 +348,18 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
                 }
             });
         }
+    } else if ([keyPath isEqualToString:@"autoDuckPercent"]) {
+        if (weDucked) {
+            dispatch_async(pauseUnpauseMusicQueue, ^{
+                // Recalculate ducked volume and update the player volume
+                float duckingFactor = (float)userDefaults.autoDuckPercent / 100.0f;
+                duckedVolume = (int)(static_cast<float>(originalVolume) * duckingFactor);
+                if (duckedVolume >= originalVolume && originalVolume > 0) {
+                    duckedVolume = originalVolume - 1;
+                }
+                [self setMusicPlayerVolume:duckedVolume];
+            });
+        }
     } else if ([keyPath isEqualToString:@"selectedMusicPlayer"]) {
         wePaused = NO;
         weDucked = NO;
@@ -347,8 +374,8 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     
     originalVolume = [self getMusicPlayerVolume];
     
-    static float const kDuckingFactor = 0.3f;
-    duckedVolume = (int)(static_cast<float>(originalVolume) * kDuckingFactor);
+    float duckingFactor = (float)userDefaults.autoDuckPercent / 100.0f;
+    duckedVolume = (int)(static_cast<float>(originalVolume) * duckingFactor);
     if (duckedVolume >= originalVolume && originalVolume > 0) {
         duckedVolume = originalVolume - 1;
     }
@@ -368,7 +395,7 @@ static Float32 const kUnpauseDelayWeightingFactor = 0.1f;
     DebugMsg("BGMAutoPauseMusic::unduckMusicPlayer: currentVolume=%d, expectedDuckedVolume=%d, originalVolume=%d",
              currentVolume, duckedVolume, originalVolume);
              
-    if (currentVolume == duckedVolume) {
+    if (std::abs(currentVolume - duckedVolume) <= 1) {
         DebugMsg("BGMAutoPauseMusic::unduckMusicPlayer: Restoring volume to originalVolume=%d", originalVolume);
         [self setMusicPlayerVolume:originalVolume];
     } else {

--- a/BGMApp/BGMApp/BGMUserDefaults.h
+++ b/BGMApp/BGMApp/BGMUserDefaults.h
@@ -44,6 +44,7 @@
 @property NSString* __nullable selectedMusicPlayerID;
 
 @property BOOL autoPauseMusicEnabled;
+@property BOOL autoDuckMusic;
 
 // The UIDs of the output devices most recently selected by the user. The most-recently selected
 // device is at index 0. See BGMPreferredOutputDevices.

--- a/BGMApp/BGMApp/BGMUserDefaults.h
+++ b/BGMApp/BGMApp/BGMUserDefaults.h
@@ -45,6 +45,7 @@
 
 @property BOOL autoPauseMusicEnabled;
 @property BOOL autoDuckMusic;
+@property NSUInteger autoDuckPercent;
 
 // The UIDs of the output devices most recently selected by the user. The most-recently selected
 // device is at index 0. See BGMPreferredOutputDevices.

--- a/BGMApp/BGMApp/BGMUserDefaults.m
+++ b/BGMApp/BGMApp/BGMUserDefaults.m
@@ -32,6 +32,7 @@
 // Keys
 static NSString* const kDefaultKeyAutoPauseMusicEnabled = @"AutoPauseMusicEnabled";
 static NSString* const kDefaultKeyAutoDuckMusic          = @"AutoDuckMusic";
+static NSString* const kDefaultKeyAutoDuckPercent        = @"AutoDuckPercent";
 static NSString* const kDefaultKeySelectedMusicPlayerID = @"SelectedMusicPlayerID";
 static NSString* const kDefaultKeyPreferredDeviceUIDs   = @"PreferredDeviceUIDs";
 static NSString* const kDefaultKeyStatusBarIcon         = @"StatusBarIcon";
@@ -64,7 +65,8 @@ static NSString* const kKeychainLabelGPMDPAuthCode =
             kDefaultKeyAutoPauseMusicEnabled: @YES,
             kDefaultKeyPauseDelayMS: @1500,
             kDefaultKeyMaxUnpauseDelayMS: @3500,
-            kDefaultKeyAutoDuckMusic: @NO
+            kDefaultKeyAutoDuckMusic: @NO,
+            kDefaultKeyAutoDuckPercent: @30
         };
 
         if (defaults) {
@@ -105,6 +107,16 @@ static NSString* const kKeychainLabelGPMDPAuthCode =
 
 - (void) setAutoDuckMusic:(BOOL)autoDuckMusic {
     [self setBool:kDefaultKeyAutoDuckMusic to:autoDuckMusic];
+}
+
+- (NSUInteger) autoDuckPercent {
+    NSInteger percent = [self getInt:kDefaultKeyAutoDuckPercent or:30];
+    return (NSUInteger)MAX(0, MIN(100, percent));
+}
+
+- (void) setAutoDuckPercent:(NSUInteger)autoDuckPercent {
+    NSUInteger clampedPercent = MAX(0, MIN(100, autoDuckPercent));
+    [self setInt:kDefaultKeyAutoDuckPercent to:(NSInteger)clampedPercent];
 }
 
 #pragma mark Auto-pause Delays

--- a/BGMApp/BGMApp/BGMUserDefaults.m
+++ b/BGMApp/BGMApp/BGMUserDefaults.m
@@ -31,6 +31,7 @@
 
 // Keys
 static NSString* const kDefaultKeyAutoPauseMusicEnabled = @"AutoPauseMusicEnabled";
+static NSString* const kDefaultKeyAutoDuckMusic          = @"AutoDuckMusic";
 static NSString* const kDefaultKeySelectedMusicPlayerID = @"SelectedMusicPlayerID";
 static NSString* const kDefaultKeyPreferredDeviceUIDs   = @"PreferredDeviceUIDs";
 static NSString* const kDefaultKeyStatusBarIcon         = @"StatusBarIcon";
@@ -62,7 +63,8 @@ static NSString* const kKeychainLabelGPMDPAuthCode =
         NSDictionary* defaultsDict = @{ 
             kDefaultKeyAutoPauseMusicEnabled: @YES,
             kDefaultKeyPauseDelayMS: @1500,
-            kDefaultKeyMaxUnpauseDelayMS: @3500
+            kDefaultKeyMaxUnpauseDelayMS: @3500,
+            kDefaultKeyAutoDuckMusic: @NO
         };
 
         if (defaults) {
@@ -93,6 +95,16 @@ static NSString* const kKeychainLabelGPMDPAuthCode =
 
 - (void) setAutoPauseMusicEnabled:(BOOL)autoPauseMusicEnabled {
     [self setBool:kDefaultKeyAutoPauseMusicEnabled to:autoPauseMusicEnabled];
+}
+
+#pragma mark Auto-duck
+
+- (BOOL) autoDuckMusic {
+    return [self getBool:kDefaultKeyAutoDuckMusic];
+}
+
+- (void) setAutoDuckMusic:(BOOL)autoDuckMusic {
+    [self setBool:kDefaultKeyAutoDuckMusic to:autoDuckMusic];
 }
 
 #pragma mark Auto-pause Delays

--- a/BGMApp/BGMApp/Preferences/BGMAutoPauseMusicPrefs.h
+++ b/BGMApp/BGMApp/Preferences/BGMAutoPauseMusicPrefs.h
@@ -34,7 +34,8 @@
 
 - (id) initWithPreferencesMenu:(NSMenu*)inPrefsMenu
                   audioDevices:(BGMAudioDeviceManager*)inAudioDevices
-                  musicPlayers:(BGMMusicPlayers*)inMusicPlayers;
+                  musicPlayers:(BGMMusicPlayers*)inMusicPlayers
+                  userDefaults:(BGMUserDefaults*)inUserDefaults;
 
 @end
 

--- a/BGMApp/BGMApp/Preferences/BGMAutoPauseMusicPrefs.mm
+++ b/BGMApp/BGMApp/Preferences/BGMAutoPauseMusicPrefs.mm
@@ -26,6 +26,7 @@
 // Local Includes
 #import "BGM_Types.h"
 #import "BGMMusicPlayer.h"
+#import "BGMUserDefaults.h"
 
 
 #pragma clang assume_nonnull begin
@@ -36,17 +37,20 @@ static NSInteger const kPrefsMenuAutoPauseHeaderTag = 1;
 @implementation BGMAutoPauseMusicPrefs {
     BGMAudioDeviceManager* audioDevices;
     BGMMusicPlayers* musicPlayers;
+    BGMUserDefaults* userDefaults;
     NSMenu* prefsMenu;
     NSArray<NSMenuItem*>* musicPlayerMenuItems;
 }
 
 - (id) initWithPreferencesMenu:(NSMenu*)inPrefsMenu
                   audioDevices:(BGMAudioDeviceManager*)inAudioDevices
-                  musicPlayers:(BGMMusicPlayers*)inMusicPlayers {
+                  musicPlayers:(BGMMusicPlayers*)inMusicPlayers
+                  userDefaults:(BGMUserDefaults*)inUserDefaults {
     if ((self = [super init])) {
         prefsMenu = inPrefsMenu;
         audioDevices = inAudioDevices;
         musicPlayers = inMusicPlayers;
+        userDefaults = inUserDefaults;
         
         musicPlayerMenuItems = @[];
         
@@ -96,6 +100,17 @@ static NSInteger const kPrefsMenuAutoPauseHeaderTag = 1;
         menuItem.target = self;
         menuItem.indentationLevel = 1;
     }
+    
+    // Add "Duck instead of pause" menu item below the music players
+    NSInteger duckMusicItemIndex = musicPlayerItemsIndex + musicPlayers.musicPlayers.count;
+    NSMenuItem* duckMusicMenuItem = [prefsMenu insertItemWithTitle:@"Duck instead of pause"
+                                                            action:@selector(handleDuckMusicChange:)
+                                                     keyEquivalent:@""
+                                                           atIndex:duckMusicItemIndex];
+    duckMusicMenuItem.representedObject = nil;
+    duckMusicMenuItem.target = self;
+    duckMusicMenuItem.indentationLevel = 1;
+    duckMusicMenuItem.state = userDefaults.autoDuckMusic ? NSOnState : NSOffState;
 }
 
 - (void) handleMusicPlayerChange:(NSMenuItem*)sender {
@@ -110,6 +125,12 @@ static NSInteger const kPrefsMenuAutoPauseHeaderTag = 1;
         BOOL isNewlySelectedMusicPlayer = (item == sender);
         item.state = (isNewlySelectedMusicPlayer ? NSOnState : NSOffState);
     }
+}
+
+- (void) handleDuckMusicChange:(NSMenuItem*)sender {
+    BOOL nextState = (sender.state == NSOffState);
+    sender.state = nextState ? NSOnState : NSOffState;
+    userDefaults.autoDuckMusic = nextState;
 }
 
 @end

--- a/BGMApp/BGMApp/Preferences/BGMPreferencesMenu.mm
+++ b/BGMApp/BGMApp/Preferences/BGMPreferencesMenu.mm
@@ -73,7 +73,8 @@ static NSInteger const kAboutPanelMenuItemTag  = 4;
         
         autoPauseMusicPrefs = [[BGMAutoPauseMusicPrefs alloc] initWithPreferencesMenu:prefsMenu
                                                                          audioDevices:inAudioDevices
-                                                                         musicPlayers:inMusicPlayers];
+                                                                         musicPlayers:inMusicPlayers
+                                                                         userDefaults:inUserDefaults];
         
         aboutPanel = [[BGMAboutPanel alloc] initWithPanel:inAboutPanel licenseView:inAboutPanelLicenseView];
 

--- a/BGMApp/BGMApp/Preferences/BGMPreferencesMenu.mm
+++ b/BGMApp/BGMApp/Preferences/BGMPreferencesMenu.mm
@@ -59,6 +59,11 @@ static NSInteger const kAboutPanelMenuItemTag  = 4;
     NSTextField* pauseDelayLabel;
     NSTextField* maxUnpauseDelayLabel;
     BGMUserDefaults* userDefaults;
+
+    // Ducking preferences
+    NSMenuItem* duckVolumeMenuItem;
+    NSSlider* duckVolumeSlider;
+    NSTextField* duckVolumeLabel;
 }
 
 - (id) initWithBGMMenu:(NSMenu*)inBGMMenu
@@ -101,6 +106,11 @@ static NSInteger const kAboutPanelMenuItemTag  = 4;
         // Set up delay preferences
         userDefaults = inUserDefaults;
         [self setupDelayPreferences:prefsMenu];
+
+        [userDefaults addObserver:self
+                       forKeyPath:@"autoDuckMusic"
+                          options:NSKeyValueObservingOptionNew
+                          context:nil];
     }
     
     return self;
@@ -195,8 +205,36 @@ static NSInteger const kAboutPanelMenuItemTag  = 4;
     
     maxUnpauseDelayMenuItem.view = maxUnpauseDelayView;
     [prefsMenu addItem:maxUnpauseDelayMenuItem];
+
+    // Create ducking volume menu item with slider
+    duckVolumeMenuItem = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
+    NSView* duckVolumeView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 280, 25)];
     
-    // Initialize the delay sliders with current values and targets
+    // Ducking volume label
+    NSTextField* duckVolumeTitleLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(10, 5, 110, 15)];
+    duckVolumeTitleLabel.stringValue = @"Ducking Volume:";
+    duckVolumeTitleLabel.editable = NO;
+    duckVolumeTitleLabel.bordered = NO;
+    duckVolumeTitleLabel.backgroundColor = [NSColor clearColor];
+    duckVolumeTitleLabel.font = [NSFont menuFontOfSize:13];
+    [duckVolumeView addSubview:duckVolumeTitleLabel];
+    
+    // Ducking volume slider
+    duckVolumeSlider = [[NSSlider alloc] initWithFrame:NSMakeRect(115, 5, 100, 15)];
+    [duckVolumeView addSubview:duckVolumeSlider];
+    
+    // Ducking volume value label
+    duckVolumeLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(220, 5, 55, 15)];
+    duckVolumeLabel.editable = NO;
+    duckVolumeLabel.bordered = NO;
+    duckVolumeLabel.backgroundColor = [NSColor clearColor];
+    duckVolumeLabel.font = [NSFont menuFontOfSize:11];
+    [duckVolumeView addSubview:duckVolumeLabel];
+    
+    duckVolumeMenuItem.view = duckVolumeView;
+    [prefsMenu addItem:duckVolumeMenuItem];
+    
+    // Initialize the sliders with current values and targets
     [self initDelaySliders];
 }
 
@@ -216,10 +254,19 @@ static NSInteger const kAboutPanelMenuItemTag  = 4;
     maxUnpauseDelaySlider.integerValue = [self msToSliderValue:userDefaults.maxUnpauseDelayMS];
     maxUnpauseDelaySlider.target = self;
     maxUnpauseDelaySlider.action = @selector(maxUnpauseDelaySliderChanged:);
+
+    // Configure ducking volume slider (0% to 100%)
+    duckVolumeSlider.minValue = 0;
+    duckVolumeSlider.maxValue = 100;
+    duckVolumeSlider.integerValue = userDefaults.autoDuckPercent;
+    duckVolumeSlider.target = self;
+    duckVolumeSlider.action = @selector(duckVolumeSliderChanged:);
     
     // Update labels with current values
     [self updatePauseDelayLabel];
     [self updateMaxUnpauseDelayLabel];
+    [self updateDuckVolumeLabel];
+    [self updateSliderStates];
 }
 
 - (void) pauseDelaySliderChanged:(NSSlider*)sender {
@@ -283,6 +330,45 @@ static NSInteger const kAboutPanelMenuItemTag  = 4;
     double sliderValue = (log10(logInput) / 2.0) * 100.0; // 0-100
     
     return (NSInteger)MIN(MAX(sliderValue, 0), 100);
+}
+
+- (void) dealloc {
+    try {
+        [userDefaults removeObserver:self forKeyPath:@"autoDuckMusic" context:nil];
+    } catch (const std::exception& e) {
+    }
+}
+
+- (void) observeValueForKeyPath:(NSString* __nullable)keyPath
+                       ofObject:(id __nullable)object
+                         change:(NSDictionary* __nullable)change
+                        context:(void* __nullable)context
+{
+    #pragma unused (object, change, context)
+    if ([keyPath isEqualToString:@"autoDuckMusic"]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self updateSliderStates];
+        });
+    }
+}
+
+- (void) duckVolumeSliderChanged:(NSSlider*)sender {
+    userDefaults.autoDuckPercent = (NSUInteger)sender.integerValue;
+    [self updateDuckVolumeLabel];
+}
+
+- (void) updateDuckVolumeLabel {
+    duckVolumeLabel.stringValue = [NSString stringWithFormat:@"%lu%%", (unsigned long)userDefaults.autoDuckPercent];
+}
+
+- (void) updateSliderStates {
+    BOOL duckEnabled = userDefaults.autoDuckMusic;
+    duckVolumeSlider.enabled = duckEnabled;
+    if (duckEnabled) {
+        duckVolumeLabel.textColor = [NSColor controlTextColor];
+    } else {
+        duckVolumeLabel.textColor = [NSColor disabledControlTextColor];
+    }
 }
 
 @end

--- a/BGMApp/BGMAppTests/UnitTests/BGMMusicPlayersUnitTests.mm
+++ b/BGMApp/BGMAppTests/UnitTests/BGMMusicPlayersUnitTests.mm
@@ -100,6 +100,14 @@ static NSArray<NSString*>* BGMResponsibleBundleIDs(NSString* bundleID) {
     #pragma unused (autoPauseMusicEnabled)
 }
 
+- (BOOL) autoDuckMusic {
+    return NO;
+}
+
+- (void) setAutoDuckMusic:(BOOL)autoDuckMusic {
+    #pragma unused (autoDuckMusic)
+}
+
 @end
 
 // -------------------------------------------------------------------------------------------------

--- a/BGMApp/BGMAppTests/UnitTests/BGMMusicPlayersUnitTests.mm
+++ b/BGMApp/BGMAppTests/UnitTests/BGMMusicPlayersUnitTests.mm
@@ -108,6 +108,14 @@ static NSArray<NSString*>* BGMResponsibleBundleIDs(NSString* bundleID) {
     #pragma unused (autoDuckMusic)
 }
 
+- (NSUInteger) autoDuckPercent {
+    return 30;
+}
+
+- (void) setAutoDuckPercent:(NSUInteger)autoDuckPercent {
+    #pragma unused (autoDuckPercent)
+}
+
 @end
 
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR implements the auto-ducking feature requested in issue #541. When enabled, instead of pausing the selected music player when other audio starts, Background Music will temporarily duck the music player's volume, restoring it when silence returns.

### Key Changes
- **Auto-duck Toggle**: Added a checkable "Duck instead of pause" menu item under the **Auto-pause [Selected Player]** Preferences submenu. When active, the main menu title dynamically changes from "Auto-pause [Selected Player]" to "Auto-duck [Selected Player]".
- **Ducking Volume Slider**: Added a dynamic `NSSlider` for **Ducking Volume** in the Preferences submenu to allow users to set the ducking volume level (0% to 100%, defaults to 30%).
- **Reactive UI**: The Ducking Volume slider dynamically enables/disables depending on whether the auto-duck option is checked. Slider adjustments update currently-ducked player volumes in real time.
- **Audio State Transitions & Fixes**:
  - Since ducked music players continue playing audio, the device's audible state transitions to `kBGMDeviceIsSilentExceptMusic` instead of `kBGMDeviceIsSilent` when other audio stops. The listener block now correctly handles this state to trigger the unducking process.
  - Initialized and defaulted fallback volumes to `50` (the neutral midpoint raw volume in the driver curve). This fixes an issue where a 50% ducking level resulted in a no-op, and prevents unducking from boosting the player volume to `100` (400% volume boost).
  - Added a tolerance range ($\pm 1$) when comparing the current volume to the target ducked volume to account for float-to-int rounding differences by CoreAudio.

## Type of Change

- New feature

## Related Issues

Closes #541

## How to Test

1. Launch Background Music and navigate to **Preferences** -> **Auto-pause [Selected Player]**.
2. Select your music player of choice.
3. Check the **Duck instead of pause** option and verify that the main menu label updates to **Auto-duck [Selected Player]**.
4. Play music on the selected player, then play audio from another app (e.g. YouTube in Chrome).
5. Verify that the player's volume ducks to the level specified by the new **Ducking Volume** slider.
6. Verify that changing the **Ducking Volume** slider while the music is ducked updates its volume in real time.
7. Stop the other app's audio and verify that the player's volume is restored to its exact pre-ducked volume.
8. Manually adjust the player's volume while ducked. Stop the other audio and verify that the manual adjustment is preserved as the new baseline volume.