### PR TITLE
Add auto-pause support for YouTube Music in Chromium browsers

### DIFF
--- a/BGMApp/BGMApp.xcodeproj/project.pbxproj
+++ b/BGMApp/BGMApp.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		1CD9894C1ECFFCFC0014BBBF /* BGMHermes.m in Sources */ = {isa = PBXBuildFile; fileRef = 279F48761DD6D73900768A85 /* BGMHermes.m */; };
 		1CD9894D1ECFFCFC0014BBBF /* BGMVLC.m in Sources */ = {isa = PBXBuildFile; fileRef = 27379B891C7C562D0084A24C /* BGMVLC.m */; };
 		1CD9894E1ECFFCFC0014BBBF /* BGMVOX.m in Sources */ = {isa = PBXBuildFile; fileRef = 273F10DE1CC3D0B900C1C6DA /* BGMVOX.m */; };
+		8984A5C4B3F575D86537F2E3 /* BGMYouTubeMusic.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B7FC2E92F4754135ED147B9 /* BGMYouTubeMusic.m */; };
 		1CD9894F1ECFFCFC0014BBBF /* BGMPreferencesMenu.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C0BD0A71BF1B029004F4CF5 /* BGMPreferencesMenu.mm */; };
 		1CD989501ECFFCFC0014BBBF /* BGMAboutPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 27D1D6BA1DD7226C0049E707 /* BGMAboutPanel.m */; };
 		1CD989511ECFFCFC0014BBBF /* BGMAutoPauseMusicPrefs.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C0BD0A41BF1A8E6004F4CF5 /* BGMAutoPauseMusicPrefs.mm */; };
@@ -183,6 +184,7 @@
 		271677BA1C6CBDFA0080B0A2 /* CACFNumber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 271677B81C6CBDFA0080B0A2 /* CACFNumber.cpp */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-CACFNumber.cpp"; }; };
 		27379B8A1C7C562D0084A24C /* BGMVLC.m in Sources */ = {isa = PBXBuildFile; fileRef = 27379B891C7C562D0084A24C /* BGMVLC.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMVLC.m"; }; };
 		273F10DF1CC3D0B900C1C6DA /* BGMVOX.m in Sources */ = {isa = PBXBuildFile; fileRef = 273F10DE1CC3D0B900C1C6DA /* BGMVOX.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMVOX.m"; }; };
+		1A8437537A1EC25116D06729 /* BGMYouTubeMusic.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B7FC2E92F4754135ED147B9 /* BGMYouTubeMusic.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMYouTubeMusic.m"; }; };
 		2743C9EB1D852B360089613B /* BGMMusicPlayers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2743C9E81D852B350089613B /* BGMMusicPlayers.mm */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMMusicPlayers.mm"; }; };
 		2743C9EC1D852B360089613B /* BGMScriptingBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 2743C9EA1D852B350089613B /* BGMScriptingBridge.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMScriptingBridge.m"; }; };
 		2743C9F11D853FBB0089613B /* BGMUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 2743C9F01D853FBB0089613B /* BGMUserDefaults.m */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMUserDefaults.m"; }; };
@@ -194,6 +196,7 @@
 		2743CA061D86D41C0089613B /* BGMSpotify.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C2336DE1BEAE10C004C1C4E /* BGMSpotify.m */; };
 		2743CA071D86D41C0089613B /* BGMVLC.m in Sources */ = {isa = PBXBuildFile; fileRef = 27379B891C7C562D0084A24C /* BGMVLC.m */; };
 		2743CA081D86D41C0089613B /* BGMVOX.m in Sources */ = {isa = PBXBuildFile; fileRef = 273F10DE1CC3D0B900C1C6DA /* BGMVOX.m */; };
+		B595D6CA968930B14E20D652 /* BGMYouTubeMusic.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B7FC2E92F4754135ED147B9 /* BGMYouTubeMusic.m */; };
 		2743CA091D86D41C0089613B /* BGMUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 2743C9F01D853FBB0089613B /* BGMUserDefaults.m */; };
 		2743CA0A1D86D52D0089613B /* BGMAudioDeviceManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CED616B1C316E1A002CAFCF /* BGMAudioDeviceManager.mm */; };
 		2743CA0C1D86D7FA0089613B /* CACFArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CC1DF7D1BE5068A00FB8FE4 /* CACFArray.cpp */; };
@@ -398,6 +401,9 @@
 		273F10DC1CC3CF9C00C1C6DA /* VOX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VOX.h; path = "Music Players/VOX.h"; sourceTree = "<group>"; };
 		273F10DD1CC3D0B900C1C6DA /* BGMVOX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGMVOX.h; path = "Music Players/BGMVOX.h"; sourceTree = "<group>"; };
 		273F10DE1CC3D0B900C1C6DA /* BGMVOX.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BGMVOX.m; path = "Music Players/BGMVOX.m"; sourceTree = "<group>"; };
+		420729A74489B1C05DA2D4E0 /* Chromium.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Chromium.h; path = "Music Players/Chromium.h"; sourceTree = "<group>"; };
+		8EAEDE3FADC75F3DCC3BBE60 /* BGMYouTubeMusic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGMYouTubeMusic.h; path = "Music Players/BGMYouTubeMusic.h"; sourceTree = "<group>"; };
+		0B7FC2E92F4754135ED147B9 /* BGMYouTubeMusic.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BGMYouTubeMusic.m; path = "Music Players/BGMYouTubeMusic.m"; sourceTree = "<group>"; };
 		2743C9E71D852B350089613B /* BGMMusicPlayers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGMMusicPlayers.h; path = "Music Players/BGMMusicPlayers.h"; sourceTree = "<group>"; };
 		2743C9E81D852B350089613B /* BGMMusicPlayers.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = BGMMusicPlayers.mm; path = "Music Players/BGMMusicPlayers.mm"; sourceTree = "<group>"; };
 		2743C9E91D852B350089613B /* BGMScriptingBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BGMScriptingBridge.h; path = "Music Players/BGMScriptingBridge.h"; sourceTree = "<group>"; };
@@ -614,6 +620,8 @@
 				27379B891C7C562D0084A24C /* BGMVLC.m */,
 				273F10DD1CC3D0B900C1C6DA /* BGMVOX.h */,
 				273F10DE1CC3D0B900C1C6DA /* BGMVOX.m */,
+				8EAEDE3FADC75F3DCC3BBE60 /* BGMYouTubeMusic.h */,
+				0B7FC2E92F4754135ED147B9 /* BGMYouTubeMusic.m */,
 				27379B841C7C53BE0084A24C /* Supporting Files */,
 			);
 			name = "Music Players";
@@ -816,6 +824,7 @@
 				1C8D8301204238DB00A838F2 /* Swinsian.h */,
 				27379B871C7C552A0084A24C /* VLC.h */,
 				273F10DC1CC3CF9C00C1C6DA /* VOX.h */,
+				420729A74489B1C05DA2D4E0 /* Chromium.h */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -1122,6 +1131,7 @@
 				1C1962E41BC94E15008A4DF7 /* CARingBuffer.cpp in Sources */,
 				1C8D830B2042DE9600A838F2 /* BGMGooglePlayMusicDesktopPlayer.m in Sources */,
 				273F10DF1CC3D0B900C1C6DA /* BGMVOX.m in Sources */,
+				1A8437537A1EC25116D06729 /* BGMYouTubeMusic.m in Sources */,
 				1CC1DF811BE5068A00FB8FE4 /* CACFArray.cpp in Sources */,
 				279F48771DD6D73A00768A85 /* BGMHermes.m in Sources */,
 				1C0BD0A81BF1B029004F4CF5 /* BGMPreferencesMenu.mm in Sources */,
@@ -1210,6 +1220,7 @@
 				1CD9894C1ECFFCFC0014BBBF /* BGMHermes.m in Sources */,
 				1CD9894D1ECFFCFC0014BBBF /* BGMVLC.m in Sources */,
 				1CD9894E1ECFFCFC0014BBBF /* BGMVOX.m in Sources */,
+				8984A5C4B3F575D86537F2E3 /* BGMYouTubeMusic.m in Sources */,
 				1CD9894F1ECFFCFC0014BBBF /* BGMPreferencesMenu.mm in Sources */,
 				1CD989501ECFFCFC0014BBBF /* BGMAboutPanel.m in Sources */,
 				1CD989511ECFFCFC0014BBBF /* BGMAutoPauseMusicPrefs.mm in Sources */,
@@ -1314,6 +1325,7 @@
 				2743CA071D86D41C0089613B /* BGMVLC.m in Sources */,
 				1CF5423D1EAAEE4300445AD8 /* BGMAudioDevice.cpp in Sources */,
 				2743CA081D86D41C0089613B /* BGMVOX.m in Sources */,
+				B595D6CA968930B14E20D652 /* BGMYouTubeMusic.m in Sources */,
 				1C62FE5223D3EB2E00B9B68E /* Mock_CAHALAudioDevice.cpp in Sources */,
 				1C62FE5323D3EB2E00B9B68E /* MockAudioDevice.cpp in Sources */,
 				2743CA091D86D41C0089613B /* BGMUserDefaults.m in Sources */,

--- a/BGMApp/BGMApp/Music Players/BGMMusicPlayers.mm
+++ b/BGMApp/BGMApp/Music Players/BGMMusicPlayers.mm
@@ -36,6 +36,7 @@
 #import "BGMSwinsian.h"
 #import "BGMMusic.h"
 #import "BGMGooglePlayMusicDesktopPlayer.h"
+#import "BGMYouTubeMusic.h"
 
 
 #pragma clang assume_nonnull begin
@@ -58,7 +59,8 @@
                                                    [BGMDecibel class],
                                                    [BGMHermes class],
                                                    [BGMSwinsian class],
-                                                   [BGMMusic class] ];
+                                                   [BGMMusic class],
+                                                   [BGMYouTubeMusic class] ];
 
     // We only support Google Play Music Desktop Player on macOS 10.10 and higher.
     if (@available(macOS 10.10, *)) {

--- a/BGMApp/BGMApp/Music Players/BGMYouTubeMusic.h
+++ b/BGMApp/BGMApp/Music Players/BGMYouTubeMusic.h
@@ -1,0 +1,56 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGMYouTubeMusic.h
+//  BGMApp
+//
+//  Copyright © 2026 Background Music contributors
+//
+//  Auto-pause support for YouTube Music (https://music.youtube.com) running in a Chromium-based
+//  browser: Brave, Google Chrome or Microsoft Edge.
+//
+//  These browsers all ship the same AppleScript dictionary (see Chromium.h), so we use Scripting
+//  Bridge to find the tab that has YouTube Music open and to read/control its <video> element via
+//  the browser's "execute javascript" command. createInstancesWithDefaults returns one instance
+//  per installed browser.
+//
+//  Requirements and limitations:
+//
+//  - "execute javascript" only works if the user has enabled
+//    View → Developer → Allow JavaScript from Apple Events in their browser (a one-time setting
+//    that persists). If it's disabled, the browser refuses the command. When that happens we show a
+//    one-time dialog explaining how to enable it and behave as if nothing is playing.
+//
+//  - BGMDriver matches the audio it should control to the browser by its bundle ID. All of a
+//    browser's tabs share the same bundle ID, so at the driver level audio from YouTube Music is
+//    indistinguishable from audio played by any other tab of the same browser. This means
+//    auto-pause won't trigger for audio played in another tab of the same browser (and, conversely,
+//    pausing YouTube Music while another tab is still playing audio won't stop that other audio).
+//
+
+// Superclass/Protocol Import
+#import "BGMMusicPlayer.h"
+
+
+#pragma clang assume_nonnull begin
+
+@interface BGMYouTubeMusic : BGMMusicPlayerBase<BGMMusicPlayer>
+
++ (NSArray<id<BGMMusicPlayer>>*) createInstancesWithDefaults:(BGMUserDefaults*)userDefaults;
+
+@end
+
+#pragma clang assume_nonnull end

--- a/BGMApp/BGMApp/Music Players/BGMYouTubeMusic.m
+++ b/BGMApp/BGMApp/Music Players/BGMYouTubeMusic.m
@@ -1,0 +1,291 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGMYouTubeMusic.m
+//  BGMApp
+//
+//  Copyright © 2026 Background Music contributors
+//
+
+// Self Include
+#import "BGMYouTubeMusic.h"
+
+// Auto-generated Scripting Bridge header
+#import "Chromium.h"
+
+// Local Includes
+#import "BGMScriptingBridge.h"
+
+// PublicUtility Includes
+#import "CADebugMacros.h"
+
+
+#pragma clang assume_nonnull begin
+
+// The prefix a tab's URL must have for us to consider it a YouTube Music tab.
+static NSString* const kYouTubeMusicURLPrefix = @"https://music.youtube.com";
+
+// JavaScript we run in the YouTube Music tab. We control the page's <video> element directly, which
+// is more robust than trying to click buttons in the UI. YouTube Music's UI keeps itself in sync
+// with the <video> element, so pausing/playing it updates the rest of the page as well.
+
+// Returns "playing", "paused" or "none" (no <video> element on the page).
+static NSString* const kGetStateJavaScript =
+    @"(function(){var v=document.querySelector('video');if(!v)return 'none';"
+     "return (!v.paused&&!v.ended)?'playing':'paused';})()";
+
+// Pauses the video if it's playing.
+static NSString* const kPauseJavaScript =
+    @"var v=document.querySelector('video'); if(v&&!v.paused){v.pause()}";
+
+// Plays the video if it's paused.
+static NSString* const kUnpauseJavaScript =
+    @"var v=document.querySelector('video'); if(v&&v.paused){v.play()}";
+
+@implementation BGMYouTubeMusic {
+    BGMScriptingBridge* scriptingBridge;
+
+    // The human-readable name of the browser, e.g. "Brave", for use in messages.
+    NSString* browserName;
+
+    // True once we've shown the dialog explaining that the user needs to enable
+    // "Allow JavaScript from Apple Events". We only ever show it once per launch so we don't spam
+    // the user.
+    BOOL didShowAppleEventsJavaScriptDialog;
+}
+
++ (NSArray<id<BGMMusicPlayer>>*) createInstancesWithDefaults:(BGMUserDefaults*)userDefaults {
+    #pragma unused (userDefaults)
+
+    // We return one instance per browser that's actually installed. Each browser has its own fixed
+    // music player ID (generated with uuidgen). The IDs must be stable across launches and unique
+    // among all music players, so if you copy this class, generate new ones.
+    NSMutableArray<id<BGMMusicPlayer>>* instances = [NSMutableArray new];
+
+    [self addInstanceForBrowserName:@"Brave"
+                           bundleID:@"com.brave.Browser"
+                      musicPlayerID:@"C8BDAEC5-B597-402C-AB34-42549D766D3A"
+                                 to:instances];
+    [self addInstanceForBrowserName:@"Chrome"
+                           bundleID:@"com.google.Chrome"
+                      musicPlayerID:@"BF177F55-15E0-425B-B236-791DFDD51592"
+                                 to:instances];
+    [self addInstanceForBrowserName:@"Edge"
+                           bundleID:@"com.microsoft.edgemac"
+                      musicPlayerID:@"004E86D9-8277-4513-91E3-CD5F8EA1D3DF"
+                                 to:instances];
+
+    return instances;
+}
+
+// Adds a BGMYouTubeMusic instance for the given browser to instances, but only if that browser is
+// installed. The bundle ID both tells BGMDriver which process's audio to control and gives us the
+// right icon in the UI.
++ (void) addInstanceForBrowserName:(NSString*)name
+                          bundleID:(NSString*)bundleID
+                     musicPlayerID:(NSString*)musicPlayerID
+                                to:(NSMutableArray<id<BGMMusicPlayer>>*)instances {
+    // Only offer browsers the user actually has installed. absolutePathForAppBundleWithIdentifier
+    // is available on 10.13, unlike URLForApplicationWithBundleIdentifier (10.15+). It's deprecated
+    // in newer SDKs, but we still support 10.13 so we keep using it here.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    NSString* __nullable path =
+        [[NSWorkspace sharedWorkspace] absolutePathForAppBundleWithIdentifier:bundleID];
+#pragma clang diagnostic pop
+
+    if (path) {
+        [instances addObject:[[self alloc] initWithBrowserName:name
+                                                      bundleID:bundleID
+                                                 musicPlayerID:musicPlayerID]];
+    } else {
+        DebugMsg("BGMYouTubeMusic::addInstanceForBrowserName: %s not installed. Skipping.",
+                 bundleID.UTF8String);
+    }
+}
+
+- (instancetype) initWithBrowserName:(NSString*)name
+                            bundleID:(NSString*)bundleID
+                       musicPlayerID:(NSString*)musicPlayerID {
+    NSString* displayName = [NSString stringWithFormat:@"YouTube Music (%@)", name];
+
+    if ((self = [super initWithMusicPlayerID:[BGMMusicPlayerBase makeID:musicPlayerID]
+                                        name:displayName
+                                    bundleID:bundleID])) {
+        scriptingBridge = [[BGMScriptingBridge alloc] initWithMusicPlayer:self];
+        browserName = name;
+        didShowAppleEventsJavaScriptDialog = NO;
+    }
+
+    return self;
+}
+
+- (ChromiumApplication* __nullable) browser {
+    return (ChromiumApplication*)scriptingBridge.application;
+}
+
+- (void) wasSelected {
+    [super wasSelected];
+    [scriptingBridge ensurePermission];
+}
+
+// Returns the first tab (across all of the browser's windows) that has YouTube Music open, or nil
+// if there isn't one (or the browser isn't running). Scripting Bridge calls are wrapped in
+// @try/@catch because they can raise if the browser closes or misbehaves mid-iteration.
+- (ChromiumTab* __nullable) youTubeMusicTab {
+    ChromiumApplication* __nullable app = self.browser;
+
+    if (!app) {
+        return nil;
+    }
+
+    @try {
+        for (ChromiumWindow* window in [app windows]) {
+            for (ChromiumTab* tab in [window tabs]) {
+                NSString* __nullable url = tab.URL;
+
+                if (url && [url hasPrefix:kYouTubeMusicURLPrefix]) {
+                    return tab;
+                }
+            }
+        }
+    } @catch (NSException* e) {
+        DebugMsg("BGMYouTubeMusic::youTubeMusicTab: Caught exception looking for the tab: %s",
+                 e.description.UTF8String);
+    }
+
+    return nil;
+}
+
+// Runs kGetStateJavaScript in the YouTube Music tab and returns "playing", "paused" or "none".
+// Returns "none" if there's no YouTube Music tab or if we can't run JavaScript in it.
+- (NSString*) playbackState {
+    ChromiumTab* __nullable tab = self.youTubeMusicTab;
+
+    if (!tab) {
+        return @"none";
+    }
+
+    id __nullable result = nil;
+
+    @try {
+        result = [tab executeJavascript:kGetStateJavaScript];
+    } @catch (NSException* e) {
+        DebugMsg("BGMYouTubeMusic::playbackState: Caught exception running JavaScript: %s",
+                 e.description.UTF8String);
+        result = nil;
+    }
+
+    if ([result isKindOfClass:[NSString class]]) {
+        return (NSString*)result;
+    }
+
+    // There's a YouTube Music tab but we couldn't run JavaScript in it. Almost always this is
+    // because the user hasn't enabled "Allow JavaScript from Apple Events" in their browser. Explain
+    // how to fix it (once) and behave as if nothing is playing.
+    [self showAppleEventsJavaScriptDialogIfNeeded];
+
+    return @"none";
+}
+
+// Shows a one-time dialog explaining how to enable "Allow JavaScript from Apple Events". Only shown
+// when this is the selected music player, and at most once per launch.
+- (void) showAppleEventsJavaScriptDialogIfNeeded {
+    if (didShowAppleEventsJavaScriptDialog || !self.selected) {
+        return;
+    }
+
+    // Set this before we (asynchronously) show the dialog so we don't queue up more than one.
+    didShowAppleEventsJavaScriptDialog = YES;
+
+    NSString* name = browserName;
+
+    // NSAlert must run on the main thread, and runModal would block whichever thread calls it, so
+    // dispatch it. (playbackState is often called from a background thread.)
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSAlert* alert = [NSAlert new];
+        alert.messageText =
+            [NSString stringWithFormat:
+             @"Background Music needs permission to control YouTube Music in %@.", name];
+        alert.informativeText =
+            [NSString stringWithFormat:
+             @"In %@, open the View menu, then Developer, and turn on "
+             "\"Allow JavaScript from Apple Events\". You only need to do this once.\n\n"
+             "If you don't see the Developer menu, it will appear once the setting has been "
+             "enabled from Settings, or you can control YouTube Music without it by selecting a "
+             "different music player in Background Music.",
+             name];
+        [alert addButtonWithTitle:@"OK"];
+        [alert runModal];
+    });
+}
+
+- (BOOL) isRunning {
+    // We consider ourselves "running" only when the browser is open and actually has a YouTube
+    // Music tab. That way BGMApp won't try to auto-pause a browser that isn't playing music.
+    return self.browser != nil && self.youTubeMusicTab != nil;
+}
+
+- (BOOL) isPlaying {
+    return [self.playbackState isEqualToString:@"playing"];
+}
+
+- (BOOL) isPaused {
+    return [self.playbackState isEqualToString:@"paused"];
+}
+
+- (BOOL) pause {
+    BOOL wasPlaying = self.playing;
+
+    if (wasPlaying) {
+        DebugMsg("BGMYouTubeMusic::pause: Pausing YouTube Music in %s", browserName.UTF8String);
+        [self runJavaScript:kPauseJavaScript];
+    }
+
+    return wasPlaying;
+}
+
+- (BOOL) unpause {
+    BOOL wasPaused = self.paused;
+
+    if (wasPaused) {
+        DebugMsg("BGMYouTubeMusic::unpause: Unpausing YouTube Music in %s", browserName.UTF8String);
+        [self runJavaScript:kUnpauseJavaScript];
+    }
+
+    return wasPaused;
+}
+
+// Runs JavaScript in the YouTube Music tab, ignoring the result. Used for the pause/unpause
+// commands, which don't return anything useful.
+- (void) runJavaScript:(NSString*)javaScript {
+    ChromiumTab* __nullable tab = self.youTubeMusicTab;
+
+    if (!tab) {
+        return;
+    }
+
+    @try {
+        [tab executeJavascript:javaScript];
+    } @catch (NSException* e) {
+        DebugMsg("BGMYouTubeMusic::runJavaScript: Caught exception running JavaScript: %s",
+                 e.description.UTF8String);
+    }
+}
+
+@end
+
+#pragma clang assume_nonnull end

--- a/BGMApp/BGMApp/Music Players/Chromium.h
+++ b/BGMApp/BGMApp/Music Players/Chromium.h
@@ -1,0 +1,139 @@
+/*
+ * Chromium.h
+ *
+ * Generated with
+ * sdef "/Applications/Brave Browser.app" | sdp -fh --basename Chromium
+ *
+ * Chromium-based browsers (Brave, Chrome, Edge) all ship the same AppleScript
+ * dictionary, so this single header drives all of them. The Scripting Bridge
+ * classes bind at runtime to whichever browser bundle ID the SBApplication is
+ * created for.
+ */
+
+#import <AppKit/AppKit.h>
+#import <ScriptingBridge/ScriptingBridge.h>
+
+
+@class ChromiumApplication, ChromiumWindow, ChromiumTab, ChromiumBookmarkFolder, ChromiumBookmarkItem;
+
+@protocol ChromiumGenericMethods
+
+- (void) saveIn:(NSURL *)in_ as:(NSString *)as;  // Save an object.
+- (void) close;  // Close a window.
+- (void) delete;  // Delete an object.
+- (SBObject *) duplicateTo:(SBObject *)to withProperties:(NSDictionary *)withProperties;  // Copy object(s) and put the copies at a new location.
+- (SBObject *) moveTo:(SBObject *)to;  // Move object(s) to a new location.
+- (void) print;  // Print an object.
+- (void) reload;  // Reload a tab.
+- (void) goBack;  // Go Back (If Possible).
+- (void) goForward;  // Go Forward (If Possible).
+- (void) selectAll;  // Select all.
+- (void) cutSelection;  // Cut selected text (If Possible).
+// sdp emits "NS_RETURNS_NOT_RETAINED" here, but that attribute only applies to methods that return
+// an Objective-C object, so it's been removed to keep the header warning-clean.
+- (void) copySelection;  // Copy text.
+- (void) pasteSelection;  // Paste text (If Possible).
+- (void) undo;  // Undo the last change.
+- (void) redo;  // Redo the last change.
+- (void) stop;  // Stop the current tab from loading.
+- (void) viewSource;  // View the HTML source of the tab.
+- (id) executeJavascript:(NSString *)javascript;  // Execute a piece of javascript.
+
+@end
+
+
+
+/*
+ * Standard Suite
+ */
+
+// The application's top-level scripting object.
+@interface ChromiumApplication : SBApplication
+
+- (SBElementArray<ChromiumWindow *> *) windows;
+
+@property (copy, readonly) NSString *name;  // The name of the application.
+@property (readonly) BOOL frontmost;  // Is this the frontmost (active) application?
+@property (copy, readonly) NSString *version;  // The version of the application.
+
+- (void) open:(NSArray<NSURL *> *)x;  // Open a document.
+- (void) quit;  // Quit the application.
+- (BOOL) exists:(id)x;  // Verify if an object exists.
+
+@end
+
+// A window.
+@interface ChromiumWindow : SBObject <ChromiumGenericMethods>
+
+- (SBElementArray<ChromiumTab *> *) tabs;
+
+@property (copy) NSString *givenName;  // The given name of the window.
+@property (copy, readonly) NSString *name;  // The full title of the window.
+- (NSString *) id;  // The unique identifier of the window.
+@property NSInteger index;  // The index of the window, ordered front to back.
+@property NSRect bounds;  // The bounding rectangle of the window.
+@property (readonly) BOOL closeable;  // Whether the window has a close box.
+@property (readonly) BOOL minimizable;  // Whether the window can be minimized.
+@property BOOL minimized;  // Whether the window is currently minimized.
+@property (readonly) BOOL resizable;  // Whether the window can be resized.
+@property BOOL visible;  // Whether the window is currently visible.
+@property (readonly) BOOL zoomable;  // Whether the window can be zoomed.
+@property BOOL zoomed;  // Whether the window is currently zoomed.
+@property (copy, readonly) ChromiumTab *activeTab;  // Returns the currently selected tab
+@property (copy) NSString *mode;  // Represents the mode of the window which can be 'normal' or 'incognito', can be set only once during creation of the window.
+@property NSInteger activeTabIndex;  // The index of the active tab.
+
+
+@end
+
+
+
+/*
+ * Chromium Suite
+ */
+
+// The application's top-level scripting object.
+@interface ChromiumApplication (ChromiumSuite)
+
+- (SBElementArray<ChromiumBookmarkFolder *> *) bookmarkFolders;
+
+@property (copy, readonly) ChromiumBookmarkFolder *bookmarksBar;  // The bookmarks bar bookmark folder.
+@property (copy, readonly) ChromiumBookmarkFolder *otherBookmarks;  // The other bookmarks bookmark folder.
+
+@end
+
+// A tab.
+@interface ChromiumTab : SBObject <ChromiumGenericMethods>
+
+- (NSString *) id;  // Unique ID of the tab.
+@property (copy, readonly) NSString *title;  // The title of the tab.
+@property (copy) NSString *URL;  // The url visible to the user.
+@property (readonly) BOOL loading;  // Is loading?
+
+
+@end
+
+// A bookmarks folder that contains other bookmarks folder and bookmark items.
+@interface ChromiumBookmarkFolder : SBObject <ChromiumGenericMethods>
+
+- (SBElementArray<ChromiumBookmarkFolder *> *) bookmarkFolders;
+- (SBElementArray<ChromiumBookmarkItem *> *) bookmarkItems;
+
+- (NSString *) id;  // Unique ID of the bookmark folder.
+@property (copy) NSString *title;  // The title of the folder.
+@property (copy, readonly) NSNumber *index;  // Returns the index with respect to its parent bookmark folder.
+
+
+@end
+
+// An item consists of an URL and the title of a bookmark
+@interface ChromiumBookmarkItem : SBObject <ChromiumGenericMethods>
+
+- (NSString *) id;  // Unique ID of the bookmark item.
+@property (copy) NSString *title;  // The title of the bookmark item.
+@property (copy) NSString *URL;  // The URL of the bookmark.
+@property (copy, readonly) NSNumber *index;  // Returns the index with respect to its parent bookmark folder.
+
+
+@end
+

--- a/BGMDriver/BGMDriver/DeviceClients/BGM_Client.cpp
+++ b/BGMDriver/BGMDriver/DeviceClients/BGM_Client.cpp
@@ -39,6 +39,37 @@ BGM_Client::BGM_Client(const AudioServerPlugInClientInfo* inClientInfo)
     }
 }
 
+bool    BGM_Client::BundleIDMatchesMusicPlayer(const CACFString& inMusicPlayerBundleID) const
+{
+    // An unset (empty) music player bundle ID never matches anything.
+    if(!mBundleID.IsValid() ||
+       !inMusicPlayerBundleID.IsValid() ||
+       CFStringGetLength(inMusicPlayerBundleID.GetCFString()) == 0)
+    {
+        return false;
+    }
+
+    if(mBundleID == inMusicPlayerBundleID)
+    {
+        return true;
+    }
+
+    // Match child bundle IDs by prefix, e.g. "com.brave.Browser.helper" for a music player set to
+    // "com.brave.Browser". The trailing dot ensures we only match actual children and not unrelated
+    // bundle IDs that happen to share a prefix (e.g. "com.brave.BrowserBeta").
+    CFStringRef theParentPrefix =
+        CFStringCreateWithFormat(NULL, NULL, CFSTR("%@."), inMusicPlayerBundleID.GetCFString());
+
+    bool theResult = (theParentPrefix != NULL) && mBundleID.StartsWith(theParentPrefix);
+
+    if(theParentPrefix != NULL)
+    {
+        CFRelease(theParentPrefix);
+    }
+
+    return theResult;
+}
+
 void    BGM_Client::Copy(const BGM_Client& inClient)
 {
     mClientID = inClient.mClientID;

--- a/BGMDriver/BGMDriver/DeviceClients/BGM_Client.h
+++ b/BGMDriver/BGMDriver/DeviceClients/BGM_Client.h
@@ -51,7 +51,16 @@ public:
     
 private:
     void                          Copy(const BGM_Client& inClient);
-    
+
+public:
+    // True if this client's audio should be treated as coming from the music player app identified
+    // by inMusicPlayerBundleID. This is the case when the bundle IDs match exactly, or when this
+    // client's bundle ID is a child of inMusicPlayerBundleID. The child case handles apps that play
+    // their audio from helper processes with their own bundle IDs, most notably Chromium-based
+    // browsers: e.g. a client with bundle ID "com.brave.Browser.helper.renderer" belongs to the
+    // music player "com.brave.Browser".
+    bool                          BundleIDMatchesMusicPlayer(const CACFString& inMusicPlayerBundleID) const;
+
 public:
     // These fields are duplicated from AudioServerPlugInClientInfo (except the mBundleID CFStringRef is
     // wrapped in a CACFString here).

--- a/BGMDriver/BGMDriver/DeviceClients/BGM_ClientMap.cpp
+++ b/BGMDriver/BGMDriver/DeviceClients/BGM_ClientMap.cpp
@@ -191,7 +191,7 @@ void    BGM_ClientMap::UpdateMusicPlayerFlags(CACFString inMusicPlayerBundleID)
     CAMutex::Locker theShadowMapsLocker(mShadowMapsMutex);
     
     auto theIsMusicPlayerTest = [&] (BGM_Client theClient) {
-        return (theClient.mBundleID.IsValid() && theClient.mBundleID == inMusicPlayerBundleID);
+        return theClient.BundleIDMatchesMusicPlayer(inMusicPlayerBundleID);
     };
     
     UpdateMusicPlayerFlagsInShadowMaps(theIsMusicPlayerTest);

--- a/BGMDriver/BGMDriver/DeviceClients/BGM_Clients.cpp
+++ b/BGMDriver/BGMDriver/DeviceClients/BGM_Clients.cpp
@@ -62,9 +62,7 @@ void    BGM_Clients::AddClient(BGM_Client inClient)
     bool pidMatchesMusicPlayerProperty =
         (mMusicPlayerProcessIDProperty != 0 && inClient.mProcessID == mMusicPlayerProcessIDProperty);
     bool bundleIDMatchesMusicPlayerProperty =
-        (mMusicPlayerBundleIDProperty != "" &&
-         inClient.mBundleID.IsValid() &&
-         inClient.mBundleID == mMusicPlayerBundleIDProperty);
+        inClient.BundleIDMatchesMusicPlayer(mMusicPlayerBundleIDProperty);
     
     inClient.mIsMusicPlayer = (pidMatchesMusicPlayerProperty || bundleIDMatchesMusicPlayerProperty);
     

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The auto-pause feature currently supports following music players:
 + [Hermes](http://hermesapp.org/)
 + [Swinsian](https://swinsian.com/)
 + [GPMDP](https://www.googleplaymusicdesktopplayer.com/)
++ [YouTube Music](https://music.youtube.com) (in Brave/Chrome/Edge)
 
 Adding support for a new music player is usually straightforward.<sup id="a1">[1](#f1)</sup> If you don't know how to program, or just don't feel
 like it, feel free to [create an issue](https://github.com/kyleneideck/BackgroundMusic/issues/new). Otherwise, see


### PR DESCRIPTION
Adds a `BGMMusicPlayer` for YouTube Music running in Chromium-based browsers (Brave, Chrome, Edge) — one instance per installed browser. It controls the `music.youtube.com` tab's `<video>` element via ScriptingBridge's "execute javascript".

Requires enabling **View → Developer → Allow JavaScript from Apple Events** in the browser (a dialog explains this once).

The second commit fixes a related driver bug: BGM matched the music player by exact bundle ID, but browser audio is produced by helper/renderer child processes (e.g. `com.brave.Browser.helper.renderer`), not the main `com.brave.Browser` process. As a result the player never matched and auto-pause oscillated on/off. The driver now matches by exact **or** parent-prefix bundle ID (`<bundleID>.`). This is generic and also helps other browser-based players.

### Testing
1. Enable "Allow JavaScript from Apple Events" in the browser.
2. Preferences → Music Player → the browser's YouTube Music entry.
3. Play a video, then start audio in another app → YouTube Music pauses.
4. Stop the other audio → it resumes.

### Known limitation
Audio from other tabs in the same browser can't be distinguished from YouTube Music at the driver level.

### Related issues
Closes #768, closes #188, closes #511.

Related, but not fully covered here (desktop/GPMDP apps or generic browser support): #547, #551, #581, #737.
