### PR TITLE
Add a sleep timer

### DIFF
--- a/BGMApp/BGMApp.xcodeproj/project.pbxproj
+++ b/BGMApp/BGMApp.xcodeproj/project.pbxproj
@@ -84,6 +84,9 @@
 		1C837DD81F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C837DD71F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMOutputVolumeMenuItem.mm"; }; };
 		1C837DD91F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C837DD71F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm */; };
 		1C837DDA1F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C837DD71F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm */; };
+		1CBA51E70000000000000030 /* BGMSleepTimer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CBA51E70000000000000020 /* BGMSleepTimer.mm */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-BGMSleepTimer.mm"; }; };
+		1CBA51E70000000000000040 /* BGMSleepTimer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CBA51E70000000000000020 /* BGMSleepTimer.mm */; };
+		1CBA51E70000000000000050 /* BGMSleepTimer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CBA51E70000000000000020 /* BGMSleepTimer.mm */; };
 		1C86DA6A1F91EE3B000C8CCF /* CAPThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C8034C21BDAFD5700668E00 /* CAPThread.cpp */; settings = {COMPILER_FLAGS = "-frandom-seed=BGMApp-CAPThread.cpp"; }; };
 		1C8B0C6A216205BF008C5679 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C8B0C69216205BF008C5679 /* AVFoundation.framework */; };
 		1C8B0C6B21645355008C5679 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C8B0C69216205BF008C5679 /* AVFoundation.framework */; };
@@ -339,6 +342,8 @@
 		1C80DED220A6718600045BBE /* BGMAppWatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BGMAppWatcher.m; sourceTree = "<group>"; };
 		1C837DD61F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BGMOutputVolumeMenuItem.h; sourceTree = "<group>"; };
 		1C837DD71F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BGMOutputVolumeMenuItem.mm; sourceTree = "<group>"; };
+		1CBA51E70000000000000010 /* BGMSleepTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BGMSleepTimer.h; sourceTree = "<group>"; };
+		1CBA51E70000000000000020 /* BGMSleepTimer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BGMSleepTimer.mm; sourceTree = "<group>"; };
 		1C8B0C69216205BF008C5679 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		1C8D8301204238DB00A838F2 /* Swinsian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Swinsian.h; path = "Music Players/Swinsian.h"; sourceTree = "<group>"; };
 		1C8D8302204238DB00A838F2 /* BGMSwinsian.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BGMSwinsian.m; path = "Music Players/BGMSwinsian.m"; sourceTree = "<group>"; };
@@ -689,6 +694,8 @@
 				1CACCF371F3175AD007F86CA /* BGMBackgroundMusicDevice.cpp */,
 				27C457E41CF2BC2600A6C9A6 /* BGMAutoPauseMenuItem.h */,
 				27C457E51CF2BC2600A6C9A6 /* BGMAutoPauseMenuItem.m */,
+				1CBA51E70000000000000010 /* BGMSleepTimer.h */,
+				1CBA51E70000000000000020 /* BGMSleepTimer.mm */,
 				1C1465B91BCC49D1003AEFE6 /* BGMAutoPauseMusic.h */,
 				1C1465B71BCC3A73003AEFE6 /* BGMAutoPauseMusic.mm */,
 				1C4699451BD5BF2E00F78043 /* Music Players */,
@@ -1155,6 +1162,7 @@
 				2743C9EC1D852B360089613B /* BGMScriptingBridge.m in Sources */,
 				1CC6593C1F91DEB400B0CCDC /* BGMTermination.mm in Sources */,
 				1C837DD81F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm in Sources */,
+				1CBA51E70000000000000030 /* BGMSleepTimer.mm in Sources */,
 				1C9258472090287F00B8D3A6 /* BGMGooglePlayMusicDesktopPlayerConnection.m in Sources */,
 				1C1963011BCAC0F6008A4DF7 /* CACFString.cpp in Sources */,
 				9E129A412602AE620005851B /* BGMASApplication.m in Sources */,
@@ -1199,6 +1207,7 @@
 				1CD989441ECFFCFC0014BBBF /* BGMAutoPauseMenuItem.m in Sources */,
 				1CD989451ECFFCFC0014BBBF /* BGMAutoPauseMusic.mm in Sources */,
 				1C837DD91F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm in Sources */,
+				1CBA51E70000000000000040 /* BGMSleepTimer.mm in Sources */,
 				1CD989461ECFFCFC0014BBBF /* BGMMusicPlayers.mm in Sources */,
 				1CD989471ECFFCFC0014BBBF /* BGMScriptingBridge.m in Sources */,
 				1CD989481ECFFCFC0014BBBF /* BGMMusicPlayer.m in Sources */,
@@ -1291,6 +1300,7 @@
 				1CE03A59239B56740036908D /* BGMDebugLoggingMenuItem.mm in Sources */,
 				2743CA0C1D86D7FA0089613B /* CACFArray.cpp in Sources */,
 				1C837DDA1F6AA1F2004B1E60 /* BGMOutputVolumeMenuItem.mm in Sources */,
+				1CBA51E70000000000000050 /* BGMSleepTimer.mm in Sources */,
 				2743CA0D1D86D7FA0089613B /* CACFDictionary.cpp in Sources */,
 				2743CA0E1D86D7FA0089613B /* CACFNumber.cpp in Sources */,
 				2743CA0F1D86D7FA0089613B /* CACFString.cpp in Sources */,

--- a/BGMApp/BGMApp/BGMAppDelegate.mm
+++ b/BGMApp/BGMApp/BGMAppDelegate.mm
@@ -37,6 +37,7 @@
 #import "BGMOutputVolumeMenuItem.h"
 #import "BGMPreferencesMenu.h"
 #import "BGMPreferredOutputDevices.h"
+#import "BGMSleepTimer.h"
 #import "BGMStatusBarItem.h"
 #import "BGMSystemSoundsVolume.h"
 #import "BGMTermination.h"
@@ -65,6 +66,7 @@ static NSString* const kOptShowDockIcon      = @"--show-dock-icon";
 
     BGMAutoPauseMusic* autoPauseMusic;
     BGMAutoPauseMenuItem* autoPauseMenuItem;
+    BGMSleepTimer* sleepTimer;
     BGMMusicPlayers* musicPlayers;
     BGMSystemSoundsVolume* systemSoundsVolume;
     BGMOutputDeviceMenuSection* outputDeviceMenuSection;
@@ -310,6 +312,14 @@ static NSString* const kOptShowDockIcon      = @"--show-dock-icon";
                                           musicPlayers:musicPlayers
                                           userDefaults:userDefaults];
 
+    // Add the "Sleep Timer" item just below the "Auto-pause" item.
+    sleepTimer = [[BGMSleepTimer alloc] initWithAudioDevices:audioDevices
+                                                musicPlayers:musicPlayers
+                                                userDefaults:userDefaults];
+
+    NSInteger autoPauseIdx = [self.bgmMenu indexOfItem:self.autoPauseMenuItemUnwrapped];
+    [self.bgmMenu insertItem:sleepTimer.menuItem atIndex:(autoPauseIdx + 1)];
+
     [self initVolumesMenuSection];
 
     // Output device selection.
@@ -534,6 +544,7 @@ exitAfterMessageDismissed:(BOOL)fatal {
 - (void) menuNeedsUpdate:(NSMenu*)menu {
     if ([menu isEqual:self.bgmMenu]) {
         [autoPauseMenuItem parentMenuNeedsUpdate];
+        [sleepTimer parentMenuNeedsUpdate];
     } else {
         DebugMsg("BGMAppDelegate::menuNeedsUpdate: Warning: unexpected menu. menu=%s", menu.description.UTF8String);
     }

--- a/BGMApp/BGMApp/BGMSleepTimer.h
+++ b/BGMApp/BGMApp/BGMSleepTimer.h
@@ -1,0 +1,56 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGMSleepTimer.h
+//  BGMApp
+//
+//  Copyright © 2026 Background Music contributors
+//
+//  A countdown timer the user sets from the status bar menu. When it expires, BGMApp pauses the
+//  selected music player and, optionally, mutes BGMDevice's output so everything goes silent. The
+//  use case is falling asleep to music.
+//
+
+// Local Includes
+#import "BGMAudioDeviceManager.h"
+#import "BGMMusicPlayers.h"
+#import "BGMUserDefaults.h"
+
+// System Includes
+#import <Cocoa/Cocoa.h>
+
+
+#pragma clang assume_nonnull begin
+
+@interface BGMSleepTimer : NSObject
+
+// Creates the "Sleep Timer" menu item (with its submenu). Add menuItem to the main menu to show it.
+- (instancetype) initWithAudioDevices:(BGMAudioDeviceManager*)audioDevices
+                         musicPlayers:(BGMMusicPlayers*)musicPlayers
+                         userDefaults:(BGMUserDefaults*)userDefaults;
+
+- (instancetype) init NS_UNAVAILABLE;
+
+// The top-level menu item. Its title shows the remaining time while a timer is active.
+@property (readonly) NSMenuItem* menuItem;
+
+// Called when the menu containing menuItem is about to be shown, so the remaining time in the title
+// can be refreshed.
+- (void) parentMenuNeedsUpdate;
+
+@end
+
+#pragma clang assume_nonnull end

--- a/BGMApp/BGMApp/BGMSleepTimer.mm
+++ b/BGMApp/BGMApp/BGMSleepTimer.mm
@@ -1,0 +1,261 @@
+// This file is part of Background Music.
+//
+// Background Music is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 2 of the
+// License, or (at your option) any later version.
+//
+// Background Music is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Background Music. If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  BGMSleepTimer.mm
+//  BGMApp
+//
+//  Copyright © 2026 Background Music contributors
+//
+
+// Self Include
+#import "BGMSleepTimer.h"
+
+// Local Includes
+#include "BGM_Types.h"
+#import "BGM_Utils.h"
+#import "BGMMusicPlayer.h"
+
+// PublicUtility Includes
+#import "CAException.h"
+
+// STL Includes
+#import <cmath>  // std::ceil
+
+
+#pragma clang assume_nonnull begin
+
+// The scope and channel used to mute BGMDevice's output, matching BGMOutputVolumeMenuItem.
+static const AudioObjectPropertyScope   kOutputScope  = kAudioDevicePropertyScopeOutput;
+static const AudioObjectPropertyElement kOutputChannel = kMainChannel;
+
+static NSString* const kParentTitle             = @"Sleep Timer";
+static NSString* const kParentTitleActiveFormat = @"Sleep Timer (%ld min left)";
+static NSString* const kMuteMenuItemTitle       = @"Mute Output When Timer Ends";
+
+// The duration options shown in the submenu, in minutes. Zero means "Off" (no timer).
+static NSInteger const kDurationsMinutes[] = { 0, 15, 30, 45, 60, 90, 120 };
+
+@implementation BGMSleepTimer {
+    BGMAudioDeviceManager* audioDevices;
+    BGMMusicPlayers* musicPlayers;
+    BGMUserDefaults* userDefaults;
+
+    // The menu items for the duration options, in the same order as kDurationsMinutes.
+    NSArray<NSMenuItem*>* durationMenuItems;
+    // The item that toggles whether the output is muted when the timer ends.
+    NSMenuItem* muteMenuItem;
+
+    // Fires when the timer ends. Nil while no timer is active.
+    NSTimer* __nullable expiryTimer;
+    // The time the active timer will end. Nil while no timer is active.
+    NSDate* __nullable expiryDate;
+    // The duration of the active timer, in minutes. Zero while no timer is active.
+    NSInteger activeDurationMinutes;
+}
+
+@synthesize menuItem = menuItem;
+
+- (instancetype) initWithAudioDevices:(BGMAudioDeviceManager*)inAudioDevices
+                         musicPlayers:(BGMMusicPlayers*)inMusicPlayers
+                         userDefaults:(BGMUserDefaults*)inUserDefaults {
+    if ((self = [super init])) {
+        audioDevices = inAudioDevices;
+        musicPlayers = inMusicPlayers;
+        userDefaults = inUserDefaults;
+
+        activeDurationMinutes = 0;
+
+        [self buildMenuItem];
+    }
+
+    return self;
+}
+
+- (void) dealloc {
+    [self cancelTimer];
+}
+
+- (void) buildMenuItem {
+    menuItem = [[NSMenuItem alloc] initWithTitle:kParentTitle action:nil keyEquivalent:@""];
+
+    NSMenu* submenu = [[NSMenu alloc] initWithTitle:kParentTitle];
+    // We update the duration items and title ourselves, so disable auto-enabling.
+    submenu.autoenablesItems = NO;
+
+    // Add the duration options.
+    NSMutableArray<NSMenuItem*>* items = [NSMutableArray new];
+
+    for (NSUInteger i = 0; i < (sizeof(kDurationsMinutes) / sizeof(kDurationsMinutes[0])); i++) {
+        NSInteger minutes = kDurationsMinutes[i];
+        NSMenuItem* item = [[NSMenuItem alloc] initWithTitle:[BGMSleepTimer titleForMinutes:minutes]
+                                                      action:@selector(durationSelected:)
+                                               keyEquivalent:@""];
+        item.target = self;
+        item.tag = minutes;
+        // Start with "Off" selected.
+        item.state = (minutes == 0) ? NSOnState : NSOffState;
+        [submenu addItem:item];
+        [items addObject:item];
+    }
+
+    durationMenuItems = items;
+
+    [submenu addItem:[NSMenuItem separatorItem]];
+
+    // Add the toggle for muting the output when the timer ends.
+    muteMenuItem = [[NSMenuItem alloc] initWithTitle:kMuteMenuItemTitle
+                                              action:@selector(toggleMuteWhenTimerEnds)
+                                       keyEquivalent:@""];
+    muteMenuItem.target = self;
+    muteMenuItem.state = userDefaults.sleepTimerMutesOutput ? NSOnState : NSOffState;
+    [submenu addItem:muteMenuItem];
+
+    menuItem.submenu = submenu;
+}
+
+// Returns the menu item title for a duration in minutes. Zero is the "Off" option.
++ (NSString*) titleForMinutes:(NSInteger)minutes {
+    switch (minutes) {
+        case 0:   return @"Off";
+        case 15:  return @"15 Minutes";
+        case 30:  return @"30 Minutes";
+        case 45:  return @"45 Minutes";
+        case 60:  return @"1 Hour";
+        case 90:  return @"1.5 Hours";
+        case 120: return @"2 Hours";
+        default:  return [NSString stringWithFormat:@"%ld Minutes", (long)minutes];
+    }
+}
+
+#pragma mark Menu Actions
+
+- (void) durationSelected:(NSMenuItem*)item {
+    NSInteger minutes = item.tag;
+
+    if (minutes <= 0) {
+        // "Off" cancels the timer.
+        [self cancelTimer];
+    } else {
+        [self startTimerWithMinutes:minutes];
+    }
+
+    [self updateDurationCheckmarks];
+    [self updateParentTitle];
+}
+
+- (void) toggleMuteWhenTimerEnds {
+    BOOL enabled = (muteMenuItem.state != NSOnState);
+    muteMenuItem.state = enabled ? NSOnState : NSOffState;
+    userDefaults.sleepTimerMutesOutput = enabled;
+}
+
+#pragma mark Timer
+
+- (void) startTimerWithMinutes:(NSInteger)minutes {
+    [self cancelTimer];
+
+    activeDurationMinutes = minutes;
+
+    NSTimeInterval seconds = static_cast<NSTimeInterval>(minutes) * 60.0;
+    expiryDate = [NSDate dateWithTimeIntervalSinceNow:seconds];
+
+    // NSTimer keeps the main run loop scheduled and fires on the main thread, so the expiry handler
+    // can safely mutate the UI. This isn't realtime audio code, so a main-thread timer is fine.
+    expiryTimer = [NSTimer scheduledTimerWithTimeInterval:seconds
+                                                   target:self
+                                                 selector:@selector(timerDidExpire)
+                                                 userInfo:nil
+                                                  repeats:NO];
+
+    DebugMsg("BGMSleepTimer::startTimerWithMinutes: Started a %ld minute sleep timer.",
+             (long)minutes);
+}
+
+- (void) cancelTimer {
+    [expiryTimer invalidate];
+    expiryTimer = nil;
+    expiryDate = nil;
+    activeDurationMinutes = 0;
+}
+
+- (void) timerDidExpire {
+    DebugMsg("BGMSleepTimer::timerDidExpire: Sleep timer expired.");
+
+    // Pause the selected music player. -pause returns whether it actually paused anything.
+    BOOL didPause = [musicPlayers.selectedMusicPlayer pause];
+    DebugMsg("BGMSleepTimer::timerDidExpire: Paused the music player: %s",
+             didPause ? "YES" : "NO");
+
+    // Optionally mute BGMDevice's output so any other audio goes silent too.
+    if (userDefaults.sleepTimerMutesOutput) {
+        [self muteOutput];
+    }
+
+    // Reset the menu back to the "Off" state.
+    [self cancelTimer];
+    [self updateDurationCheckmarks];
+    [self updateParentTitle];
+}
+
+- (void) muteOutput {
+    // Mute BGMDevice's main output the same way the output volume slider does when set to zero. The
+    // volume slider's BGMVolumeChangeListener listens for this mute change, so its UI updates to
+    // match automatically.
+    BGMLogAndSwallowExceptions("BGMSleepTimer::muteOutput", ([&] {
+        if (audioDevices.bgmDevice.HasMuteControl(kOutputScope, kOutputChannel)) {
+            audioDevices.bgmDevice.SetMuteControlValue(kOutputScope, kOutputChannel, true);
+            DebugMsg("BGMSleepTimer::muteOutput: Muted the output.");
+        }
+    }));
+}
+
+#pragma mark UI Updates
+
+- (void) parentMenuNeedsUpdate {
+    [self updateParentTitle];
+}
+
+- (void) updateParentTitle {
+    menuItem.title = [self parentTitle];
+}
+
+- (NSString*) parentTitle {
+    if (!expiryDate) {
+        return kParentTitle;
+    }
+
+    NSTimeInterval remaining = expiryDate.timeIntervalSinceNow;
+
+    if (remaining <= 0) {
+        return kParentTitle;
+    }
+
+    // Round up so the last minute still reads "1 min left" rather than "0 min left".
+    NSInteger minutesLeft = (NSInteger)std::ceil(remaining / 60.0);
+    return [NSString stringWithFormat:kParentTitleActiveFormat, (long)minutesLeft];
+}
+
+- (void) updateDurationCheckmarks {
+    // Check the item matching the active duration (or "Off" when no timer is active) and uncheck the
+    // rest.
+    for (NSMenuItem* item in durationMenuItems) {
+        item.state = (item.tag == activeDurationMinutes) ? NSOnState : NSOffState;
+    }
+}
+
+@end
+
+#pragma clang assume_nonnull end

--- a/BGMApp/BGMApp/BGMUserDefaults.h
+++ b/BGMApp/BGMApp/BGMUserDefaults.h
@@ -45,6 +45,10 @@
 
 @property BOOL autoPauseMusicEnabled;
 
+// Whether the sleep timer mutes BGMApp's output (in addition to pausing the music player) when it
+// ends. Defaults to YES. The timer's remaining time itself is not persisted across app restarts.
+@property BOOL sleepTimerMutesOutput;
+
 // The UIDs of the output devices most recently selected by the user. The most-recently selected
 // device is at index 0. See BGMPreferredOutputDevices.
 @property NSArray<NSString*>* preferredDeviceUIDs;

--- a/BGMApp/BGMApp/BGMUserDefaults.m
+++ b/BGMApp/BGMApp/BGMUserDefaults.m
@@ -31,6 +31,7 @@
 
 // Keys
 static NSString* const kDefaultKeyAutoPauseMusicEnabled = @"AutoPauseMusicEnabled";
+static NSString* const kDefaultKeySleepTimerMutesOutput = @"SleepTimerMutesOutput";
 static NSString* const kDefaultKeySelectedMusicPlayerID = @"SelectedMusicPlayerID";
 static NSString* const kDefaultKeyPreferredDeviceUIDs   = @"PreferredDeviceUIDs";
 static NSString* const kDefaultKeyStatusBarIcon         = @"StatusBarIcon";
@@ -61,6 +62,7 @@ static NSString* const kKeychainLabelGPMDPAuthCode =
         // be selected. See BGMMusicPlayers.)
         NSDictionary* defaultsDict = @{ 
             kDefaultKeyAutoPauseMusicEnabled: @YES,
+            kDefaultKeySleepTimerMutesOutput: @YES,
             kDefaultKeyPauseDelayMS: @1500,
             kDefaultKeyMaxUnpauseDelayMS: @3500
         };
@@ -93,6 +95,16 @@ static NSString* const kKeychainLabelGPMDPAuthCode =
 
 - (void) setAutoPauseMusicEnabled:(BOOL)autoPauseMusicEnabled {
     [self setBool:kDefaultKeyAutoPauseMusicEnabled to:autoPauseMusicEnabled];
+}
+
+#pragma mark Sleep Timer
+
+- (BOOL) sleepTimerMutesOutput {
+    return [self getBool:kDefaultKeySleepTimerMutesOutput];
+}
+
+- (void) setSleepTimerMutesOutput:(BOOL)sleepTimerMutesOutput {
+    [self setBool:kDefaultKeySleepTimerMutesOutput to:sleepTimerMutesOutput];
 }
 
 #pragma mark Auto-pause Delays

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 # Overview
 
 + Automatically pause/unpause your music player when other audio sources are playing/stopped
++ Sleep timer that pauses your music (and optionally mutes the output) after a chosen countdown
 + Per-application volume control
 + Record system audio
 + No restart required to install


### PR DESCRIPTION
Adds a "Sleep Timer" menu with durations from 15 min to 2 h. When the timer expires, BGM pauses the selected music player and (optionally, on by default) mutes BGMDevice's output. The menu title shows the remaining time while open.

The mute-on-expiry choice persists via a new `sleepTimerMutesOutput` user default.

### Testing
1. Pick a duration from the Sleep Timer menu.
2. Play some audio and wait for expiry → the music player pauses and the output mutes.
