### PR TITLE
Add software output volume for devices without a hardware volume control

### DIFF
--- a/BGMApp/BGMApp/BGMAppDelegate.mm
+++ b/BGMApp/BGMApp/BGMAppDelegate.mm
@@ -168,6 +168,11 @@ static NSString* const kOptShowDockIcon      = @"--show-dock-icon";
 }
 
 - (void) continueLaunchAfterInputDevicePermissionGranted {
+    // Apply the user's software output volume setting before choosing the output device, so the
+    // initial volume mode is correct. (The menu toggle re-applies it when changed. See
+    // BGMPreferencesMenu.)
+    [audioDevices setSoftwareOutputVolumeEnabled:userDefaults.softwareOutputVolumeEnabled];
+
     // Choose an output device for BGMApp to use to play audio.
     if (![self setInitialOutputDevice]) {
         return;

--- a/BGMApp/BGMApp/BGMAudioDeviceManager.h
+++ b/BGMApp/BGMApp/BGMAudioDeviceManager.h
@@ -75,6 +75,13 @@ static const int kBGMErrorCode_ReturningEarly       = 2;
 - (BOOL) isOutputDevice:(AudioObjectID)deviceID;
 - (BOOL) isOutputDataSource:(UInt32)dataSourceID;
 
+// Enable or disable software output volume. When enabled (the default), if the output device has no
+// hardware volume control BGMDevice applies its volume to the audio in software so the volume
+// slider/keys still work. When disabled, BGMApp always mirrors the volume onto the output device's
+// hardware volume control (so the slider is disabled for outputs without one). Takes effect
+// immediately, re-evaluating the current output device's volume mode.
+- (void) setSoftwareOutputVolumeEnabled:(BOOL)enabled;
+
 // Set the audio output device that BGMApp uses.
 //
 // Returns an error if the output device couldn't be changed. If revertOnFailure is true in that case,

--- a/BGMApp/BGMApp/BGMAudioDeviceManager.mm
+++ b/BGMApp/BGMApp/BGMAudioDeviceManager.mm
@@ -224,6 +224,19 @@ static OSStatus BGMDeviceListenerProc(AudioObjectID inObjectID,
     return isOutputDataSource;
 }
 
+- (void) setSoftwareOutputVolumeEnabled:(BOOL)enabled {
+    @try {
+        [stateLock lock];
+
+        // Re-evaluates the volume mode for the current output device (if one is set).
+        BGMLogAndSwallowExceptions("BGMAudioDeviceManager::setSoftwareOutputVolumeEnabled", [&] {
+            deviceControlSync.SetSoftwareVolumeEnabled(enabled);
+        });
+    } @finally {
+        [stateLock unlock];
+    }
+}
+
 #pragma mark Output Device
 
 - (NSError* __nullable) setOutputDeviceWithID:(AudioObjectID)deviceID

--- a/BGMApp/BGMApp/BGMBackgroundMusicDevice.cpp
+++ b/BGMApp/BGMApp/BGMBackgroundMusicDevice.cpp
@@ -374,4 +374,24 @@ bool BGMBackgroundMusicDevice::GetDebugLoggingEnabled() const
     return enabled;
 }
 
+#pragma mark Software Output Volume
+
+bool BGMBackgroundMusicDevice::GetApplyingVolumeToAudio() const
+{
+    CFTypeRef propertyDataRef = GetPropertyData_CFType(kBGMApplyingVolumeToAudioAddress);
+
+    ThrowIfNULL(propertyDataRef,
+                CAException(kAudioHardwareIllegalOperationError),
+                "BGMBackgroundMusicDevice::GetApplyingVolumeToAudio: !propertyDataRef");
+
+    ThrowIf(CFGetTypeID(propertyDataRef) != CFBooleanGetTypeID(),
+            CAException(kAudioHardwareIllegalOperationError),
+            "BGMBackgroundMusicDevice::GetApplyingVolumeToAudio: Property was not a CFBoolean");
+
+    bool applying = CFBooleanGetValue(static_cast<CFBooleanRef>(propertyDataRef));
+    CFRelease(propertyDataRef);
+
+    return applying;
+}
+
 #pragma clang assume_nonnull end

--- a/BGMApp/BGMApp/BGMBackgroundMusicDevice.h
+++ b/BGMApp/BGMApp/BGMBackgroundMusicDevice.h
@@ -199,6 +199,30 @@ public:
                             SetPropertyData_CFType(kBGMDebugLoggingEnabledAddress,
                                                    inEnabled ? kCFBooleanTrue : kCFBooleanFalse); }
 
+#pragma mark Software Output Volume
+
+public:
+    /*!
+     @return True if BGMDevice is currently applying its (main output) volume to the audio it
+             outputs in software, rather than relying on BGMApp to mirror the volume onto the real
+             output device's hardware volume control.
+     @throws CAException If the HAL returns an error or a non-boolean value.
+     @see kAudioDeviceCustomPropertyApplyingVolumeToAudio in BGM_Types.h.
+     */
+    bool                GetApplyingVolumeToAudio() const;
+    /*!
+     Tell BGMDevice whether to apply its (main output) volume to the audio it outputs in software.
+     BGMApp enables this when the selected output device has no hardware volume control so the volume
+     slider/keys still work.
+
+     @throws CAException If the HAL returns an error.
+     @see kAudioDeviceCustomPropertyApplyingVolumeToAudio in BGM_Types.h.
+     */
+    void                SetApplyingVolumeToAudio(bool inApplyingVolumeToAudio) {
+                            SetPropertyData_CFType(kBGMApplyingVolumeToAudioAddress,
+                                                   inApplyingVolumeToAudio ? kCFBooleanTrue
+                                                                           : kCFBooleanFalse); }
+
 #pragma mark UI Sounds Instance
 
 public:

--- a/BGMApp/BGMApp/BGMDeviceControlSync.cpp
+++ b/BGMApp/BGMApp/BGMDeviceControlSync.cpp
@@ -73,21 +73,53 @@ void    BGMDeviceControlSync::Activate()
     {
         DebugMsg("BGMDeviceControlSync::Activate: Activating control sync");
 
+        // Decide whether to apply the output volume in software. We do this when software output
+        // volume is enabled and the output device has no hardware volume control (e.g. an HDMI
+        // monitor). In that case BGMDevice applies its volume to the audio itself (in BGMDriver) and
+        // we keep BGMDevice's volume control enabled so the slider stays usable. Otherwise we keep
+        // the original behaviour: mirror BGMDevice's volume onto the output device's hardware volume
+        // control.
+        bool outputHasVolume = false;
+        BGMLogAndSwallowExceptionsMsg("BGMDeviceControlSync::Activate", "Output volume check", [&] {
+            outputHasVolume =
+                BGMDeviceControlsList::OutputDeviceHasSettableVolume(mOutputDevice);
+        });
+
+        mInSoftwareVolumeMode = mSoftwareVolumeEnabled && !outputHasVolume;
+
+        DebugMsg("BGMDeviceControlSync::Activate: %s software output volume",
+                 mInSoftwareVolumeMode ? "Using" : "Not using");
+
+        // Tell BGMDriver whether to apply BGMDevice's volume to the audio it outputs.
+        BGMLogAndSwallowExceptionsMsg("BGMDeviceControlSync::Activate", "Applying-volume property",
+                                      [&] {
+            mBGMDevice.SetPropertyData_CFType(kBGMApplyingVolumeToAudioAddress,
+                                              mInSoftwareVolumeMode ? kCFBooleanTrue
+                                                                    : kCFBooleanFalse);
+        });
+
         // Disable BGMDevice controls that the output device doesn't have and reenable any that were
-        // disabled for the previous output device.
+        // disabled for the previous output device. In software volume mode we keep the volume
+        // control enabled regardless of the output device.
         //
         // Continue anyway if this fails because it's better to have extra/missing controls than to
         // be unable to use the device.
         BGMLogAndSwallowExceptionsMsg("BGMDeviceControlSync::Activate", "Controls list", [&] {
-            bool wasUpdated = mBGMDeviceControlsList.MatchControlsListOf(mOutputDevice);
+            bool wasUpdated =
+                mBGMDeviceControlsList.MatchControlsListOf(mOutputDevice, mInSoftwareVolumeMode);
             if(wasUpdated)
             {
                 mBGMDeviceControlsList.PropagateControlListChange();
             }
         });
 
-        // Init BGMDevice controls to match output device
-        mBGMDevice.CopyVolumeFrom(mOutputDevice, kAudioObjectPropertyScopeOutput);
+        // Init BGMDevice controls to match output device. In software volume mode we leave
+        // BGMDevice's volume as the user set it (the output device has no volume to copy anyway) so
+        // we don't reset the user's chosen software volume.
+        if(!mInSoftwareVolumeMode)
+        {
+            mBGMDevice.CopyVolumeFrom(mOutputDevice, kAudioObjectPropertyScopeOutput);
+        }
         mBGMDevice.CopyMuteFrom(mOutputDevice, kAudioObjectPropertyScopeOutput);
 
         // Register listeners for volume and mute values
@@ -166,6 +198,25 @@ void    BGMDeviceControlSync::SetDevices(AudioObjectID inBGMDevice, AudioObjectI
     }
 }
 
+void    BGMDeviceControlSync::SetSoftwareVolumeEnabled(bool inEnabled)
+{
+    CAMutex::Locker locker(mMutex);
+
+    if(mSoftwareVolumeEnabled == inEnabled)
+    {
+        return;
+    }
+
+    mSoftwareVolumeEnabled = inEnabled;
+
+    // Re-evaluate the mode with the new setting. Deactivate/Activate here mirror SetDevices.
+    if(mActive)
+    {
+        Deactivate();
+        Activate();
+    }
+}
+
 #pragma mark Listener Procs
 
 // static
@@ -207,8 +258,11 @@ OSStatus    BGMDeviceControlSync::BGMDeviceListenerProc(AudioObjectID inObjectID
                 {
                     CAMutex::Locker locker(refCon->mMutex);
 
-                    // Update the output device's volume.
-                    if(checkState())
+                    // Update the output device's volume. In software volume mode BGMDevice applies
+                    // its volume to the audio itself, so we must not also mirror it onto the output
+                    // device (that would either double-attenuate or, more likely, do nothing since
+                    // the output has no volume control).
+                    if(checkState() && !refCon->mInSoftwareVolumeMode)
                     {
                         refCon->mOutputDevice.CopyVolumeFrom(refCon->mBGMDevice, scope);
                     }

--- a/BGMApp/BGMApp/BGMDeviceControlSync.h
+++ b/BGMApp/BGMApp/BGMDeviceControlSync.h
@@ -93,6 +93,20 @@ public:
      */
     void                SetDevices(AudioObjectID inBGMDevice, AudioObjectID inOutputDevice);
 
+    /*!
+     Enable or disable software output volume. When enabled (the default) and the output device has
+     no hardware volume control, BGMDevice applies its volume to the audio in software (via
+     BGMDriver) so the volume slider/keys still work, and its volume is not mirrored onto the output
+     device. When disabled, BGMDevice's volume is always mirrored onto the output device's hardware
+     volume control (the original behaviour), so the slider is disabled for outputs without one.
+
+     Re-evaluates the current mode immediately if this BGMDeviceControlSync is active.
+
+     @throws CAException if re-evaluating the mode fails (the object will be deactivated in that
+                         case, matching SetDevices).
+     */
+    void                SetSoftwareVolumeEnabled(bool inEnabled);
+
 #pragma mark Listener Procs
     
 private:
@@ -105,6 +119,13 @@ private:
 private:
     CAMutex             mMutex         { "Device Control Sync" };
     bool                mActive        = false;
+
+    // Whether software output volume is enabled (see SetSoftwareVolumeEnabled). Persisted by BGMApp;
+    // defaults to true.
+    bool                mSoftwareVolumeEnabled = true;
+    // Whether we're currently applying the output volume in software, i.e. mSoftwareVolumeEnabled is
+    // true and the output device has no hardware volume control. Guarded by mMutex.
+    bool                mInSoftwareVolumeMode  = false;
 
     CAHALAudioSystemObject mAudioSystem;
     

--- a/BGMApp/BGMApp/BGMDeviceControlsList.cpp
+++ b/BGMApp/BGMApp/BGMDeviceControlsList.cpp
@@ -133,7 +133,43 @@ void    BGMDeviceControlsList::SetBGMDevice(AudioObjectID inBGMDeviceID)
 
 #pragma mark Update Controls List
 
-bool    BGMDeviceControlsList::MatchControlsListOf(AudioObjectID inDeviceID)
+bool    BGMDeviceControlsList::OutputDeviceHasSettableVolume(AudioObjectID inDeviceID)
+{
+    AudioObjectPropertyScope inScope = kAudioObjectPropertyScopeOutput;
+
+    BGMAudioDevice device(inDeviceID);
+
+    bool hasVolume =
+        device.HasSettableMainVolume(inScope) || device.HasSettableVirtualMainVolume(inScope);
+
+    if(!hasVolume)
+    {
+        // Check for per-channel volume controls.
+        UInt32 numChannels =
+            device.GetTotalNumberChannels(inScope == kAudioObjectPropertyScopeInput);
+
+        for(UInt32 channel = 1; channel <= numChannels; channel++)
+        {
+            BGMLogAndSwallowExceptionsMsg("BGMDeviceControlsList::OutputDeviceHasSettableVolume",
+                                          "Checking for channel volume controls",
+                                          ([&] {
+                hasVolume =
+                    (device.HasVolumeControl(inScope, channel)
+                            && device.VolumeControlIsSettable(inScope, channel));
+            }));
+
+            if(hasVolume)
+            {
+                break;
+            }
+        }
+    }
+
+    return hasVolume;
+}
+
+bool    BGMDeviceControlsList::MatchControlsListOf(AudioObjectID inDeviceID,
+                                                  bool inKeepVolumeEnabled)
 {
     CAMutex::Locker locker(mMutex);
 
@@ -188,31 +224,9 @@ bool    BGMDeviceControlsList::MatchControlsListOf(AudioObjectID inDeviceID)
     BGMAudioDevice device(inDeviceID);
     bool hasMute = device.HasSettableMainMute(inScope);
 
-    bool hasVolume =
-        device.HasSettableMainVolume(inScope) || device.HasSettableVirtualMainVolume(inScope);
-
-    if(!hasVolume)
-    {
-        // Check for per-channel volume controls.
-        UInt32 numChannels =
-            device.GetTotalNumberChannels(inScope == kAudioObjectPropertyScopeInput);
-
-        for(UInt32 channel = 1; channel <= numChannels; channel++)
-        {
-            BGMLogAndSwallowExceptionsMsg("BGMDeviceControlsList::MatchControlsListOf",
-                                          "Checking for channel volume controls",
-                                          ([&] {
-                hasVolume =
-                    (device.HasVolumeControl(inScope, channel)
-                            && device.VolumeControlIsSettable(inScope, channel));
-            }));
-
-            if(hasVolume)
-            {
-                break;
-            }
-        }
-    }
+    // When applying the output volume in software, keep BGMDevice's volume control enabled even if
+    // the output device has no volume control of its own.
+    bool hasVolume = inKeepVolumeEnabled || OutputDeviceHasSettableVolume(inDeviceID);
 
     // Tell BGMDevice to enable/disable its controls to match the output device.
     bool deviceUpdated = false;

--- a/BGMApp/BGMApp/BGMDeviceControlsList.h
+++ b/BGMApp/BGMApp/BGMDeviceControlsList.h
@@ -65,10 +65,22 @@ public:
      the given device, and disable the ones that can't.
 
      @param inDeviceID The ID of the device.
+     @param inKeepVolumeEnabled If true, keep BGMDevice's volume control enabled even if the given
+                                device has no volume control. Used for software output volume, where
+                                BGMDevice applies its volume to the audio itself so the slider stays
+                                usable on devices without a hardware volume control.
      @return True if BGMDevice's list of controls was updated.
      @throws CAException if an error is received from either device.
      */
-    bool                MatchControlsListOf(AudioObjectID inDeviceID);
+    bool                MatchControlsListOf(AudioObjectID inDeviceID,
+                                            bool inKeepVolumeEnabled = false);
+
+    /*!
+     @param inDeviceID The ID of the device.
+     @return True if the given device has a settable main, virtual main or per-channel volume
+             control with output scope.
+     */
+    static bool         OutputDeviceHasSettableVolume(AudioObjectID inDeviceID);
     /*!
      After updating BGMDevice's controls list, we need to change the default device so programs
      (including OS X's audio UI) will update themselves. We could just change to the real output

--- a/BGMApp/BGMApp/BGMUserDefaults.h
+++ b/BGMApp/BGMApp/BGMUserDefaults.h
@@ -45,6 +45,11 @@
 
 @property BOOL autoPauseMusicEnabled;
 
+// Whether to apply the output volume in software when the selected output device has no hardware
+// volume control (e.g. an HDMI monitor). When enabled, the volume slider/keys keep working on such
+// devices because BGMDevice attenuates the audio itself. Defaults to YES.
+@property BOOL softwareOutputVolumeEnabled;
+
 // The UIDs of the output devices most recently selected by the user. The most-recently selected
 // device is at index 0. See BGMPreferredOutputDevices.
 @property NSArray<NSString*>* preferredDeviceUIDs;

--- a/BGMApp/BGMApp/BGMUserDefaults.m
+++ b/BGMApp/BGMApp/BGMUserDefaults.m
@@ -31,6 +31,7 @@
 
 // Keys
 static NSString* const kDefaultKeyAutoPauseMusicEnabled = @"AutoPauseMusicEnabled";
+static NSString* const kDefaultKeySoftwareOutputVolumeEnabled = @"SoftwareOutputVolumeEnabled";
 static NSString* const kDefaultKeySelectedMusicPlayerID = @"SelectedMusicPlayerID";
 static NSString* const kDefaultKeyPreferredDeviceUIDs   = @"PreferredDeviceUIDs";
 static NSString* const kDefaultKeyStatusBarIcon         = @"StatusBarIcon";
@@ -59,8 +60,9 @@ static NSString* const kKeychainLabelGPMDPAuthCode =
         // here so we know when it's never been set. (If it hasn't, we try using BGMDevice's
         // kAudioDeviceCustomPropertyMusicPlayerBundleID property to tell which music player should
         // be selected. See BGMMusicPlayers.)
-        NSDictionary* defaultsDict = @{ 
+        NSDictionary* defaultsDict = @{
             kDefaultKeyAutoPauseMusicEnabled: @YES,
+            kDefaultKeySoftwareOutputVolumeEnabled: @YES,
             kDefaultKeyPauseDelayMS: @1500,
             kDefaultKeyMaxUnpauseDelayMS: @3500
         };
@@ -93,6 +95,16 @@ static NSString* const kKeychainLabelGPMDPAuthCode =
 
 - (void) setAutoPauseMusicEnabled:(BOOL)autoPauseMusicEnabled {
     [self setBool:kDefaultKeyAutoPauseMusicEnabled to:autoPauseMusicEnabled];
+}
+
+#pragma mark Software Output Volume
+
+- (BOOL) softwareOutputVolumeEnabled {
+    return [self getBool:kDefaultKeySoftwareOutputVolumeEnabled];
+}
+
+- (void) setSoftwareOutputVolumeEnabled:(BOOL)softwareOutputVolumeEnabled {
+    [self setBool:kDefaultKeySoftwareOutputVolumeEnabled to:softwareOutputVolumeEnabled];
 }
 
 #pragma mark Auto-pause Delays

--- a/BGMApp/BGMApp/Preferences/BGMPreferencesMenu.mm
+++ b/BGMApp/BGMApp/Preferences/BGMPreferencesMenu.mm
@@ -59,6 +59,10 @@ static NSInteger const kAboutPanelMenuItemTag  = 4;
     NSTextField* pauseDelayLabel;
     NSTextField* maxUnpauseDelayLabel;
     BGMUserDefaults* userDefaults;
+
+    // Software output volume preference.
+    BGMAudioDeviceManager* audioDevices;
+    NSMenuItem* softwareOutputVolumeMenuItem;
 }
 
 - (id) initWithBGMMenu:(NSMenu*)inBGMMenu
@@ -99,10 +103,45 @@ static NSInteger const kAboutPanelMenuItemTag  = 4;
         
         // Set up delay preferences
         userDefaults = inUserDefaults;
+
+        // Set up the software output volume preference.
+        audioDevices = inAudioDevices;
+        [self setupSoftwareOutputVolumePreference:prefsMenu];
+
         [self setupDelayPreferences:prefsMenu];
     }
-    
+
     return self;
+}
+
+- (void) setupSoftwareOutputVolumePreference:(NSMenu*)prefsMenu {
+    // Add a checkbox that toggles software output volume. See
+    // BGMUserDefaults.softwareOutputVolumeEnabled and BGMDeviceControlSync.
+    [prefsMenu addItem:[NSMenuItem separatorItem]];
+
+    softwareOutputVolumeMenuItem =
+        [[NSMenuItem alloc] initWithTitle:@"Software volume for outputs without volume control"
+                                   action:@selector(toggleSoftwareOutputVolume)
+                            keyEquivalent:@""];
+    softwareOutputVolumeMenuItem.target = self;
+    softwareOutputVolumeMenuItem.state =
+        userDefaults.softwareOutputVolumeEnabled ? NSControlStateValueOn : NSControlStateValueOff;
+    softwareOutputVolumeMenuItem.toolTip =
+        @"When your output device has no volume control of its own (e.g. some HDMI displays), "
+         "Background Music adjusts the volume in software so the volume slider and keys still work.";
+
+    [prefsMenu addItem:softwareOutputVolumeMenuItem];
+}
+
+- (void) toggleSoftwareOutputVolume {
+    BOOL enabled = (softwareOutputVolumeMenuItem.state != NSControlStateValueOn);
+
+    softwareOutputVolumeMenuItem.state =
+        enabled ? NSControlStateValueOn : NSControlStateValueOff;
+
+    // Persist the change and re-evaluate the current output device's volume mode.
+    userDefaults.softwareOutputVolumeEnabled = enabled;
+    [audioDevices setSoftwareOutputVolumeEnabled:enabled];
 }
 
 - (void) useBGMStatusBarIcon {

--- a/BGMDriver/BGMDriver/BGM_Device.cpp
+++ b/BGMDriver/BGMDriver/BGM_Device.cpp
@@ -327,7 +327,13 @@ bool	BGM_Device::Device_HasProperty(AudioObjectID inObjectID, pid_t inClientPID,
         case kAudioDeviceCustomPropertyDebugLoggingEnabled:
 			theAnswer = true;
 			break;
-			
+
+        case kAudioDeviceCustomPropertyApplyingVolumeToAudio:
+            // Only the main BGMDevice instance applies its volume to audio on request from BGMApp.
+            // The UI sounds instance always applies its own volume and doesn't expose this property.
+            theAnswer = (GetObjectID() == kObjectID_Device);
+            break;
+
 		case kAudioDevicePropertyLatency:
 		case kAudioDevicePropertySafetyOffset:
 		case kAudioDevicePropertyPreferredChannelsForStereo:
@@ -375,7 +381,12 @@ bool	BGM_Device::Device_IsPropertySettable(AudioObjectID inObjectID, pid_t inCli
         case kAudioDeviceCustomPropertyDebugLoggingEnabled:
 			theAnswer = true;
 			break;
-		
+
+        case kAudioDeviceCustomPropertyApplyingVolumeToAudio:
+            // Settable, but only on the main BGMDevice instance. See Device_HasProperty.
+            theAnswer = (GetObjectID() == kObjectID_Device);
+            break;
+
 		default:
 			theAnswer = BGM_AbstractDevice::IsPropertySettable(inObjectID, inClientPID, inAddress);
 			break;
@@ -459,7 +470,9 @@ UInt32	BGM_Device::Device_GetPropertyDataSize(AudioObjectID inObjectID, pid_t in
             break;
             
         case kAudioObjectPropertyCustomPropertyInfoList:
-            theAnswer = sizeof(AudioServerPlugInCustomPropertyInfo) * 7;
+            // The main BGMDevice instance also exposes kAudioDeviceCustomPropertyApplyingVolumeToAudio.
+            theAnswer = sizeof(AudioServerPlugInCustomPropertyInfo) *
+                    ((GetObjectID() == kObjectID_Device) ? 8 : 7);
             break;
             
         case kAudioDeviceCustomPropertyDeviceAudibleState:
@@ -489,7 +502,11 @@ UInt32	BGM_Device::Device_GetPropertyDataSize(AudioObjectID inObjectID, pid_t in
         case kAudioDeviceCustomPropertyDebugLoggingEnabled:
             theAnswer = sizeof(CFBooleanRef);
             break;
-		
+
+        case kAudioDeviceCustomPropertyApplyingVolumeToAudio:
+            theAnswer = sizeof(CFBooleanRef);
+            break;
+
 		default:
 			theAnswer = BGM_AbstractDevice::GetPropertyDataSize(inObjectID, inClientPID, inAddress, inQualifierDataSize, inQualifierData);
 			break;
@@ -888,13 +905,17 @@ void	BGM_Device::Device_GetPropertyData(AudioObjectID inObjectID, pid_t inClient
             
         case kAudioObjectPropertyCustomPropertyInfoList:
             theNumberItemsToFetch = inDataSize / sizeof(AudioServerPlugInCustomPropertyInfo);
-            
-            //	clamp it to the number of items we have
-            if(theNumberItemsToFetch > 7)
+
+            //	clamp it to the number of items we have. The main BGMDevice instance has one extra
+            //	custom property, kAudioDeviceCustomPropertyApplyingVolumeToAudio.
             {
-                theNumberItemsToFetch = 7;
+                UInt32 theNumberOfCustomProperties = (GetObjectID() == kObjectID_Device) ? 8 : 7;
+                if(theNumberItemsToFetch > theNumberOfCustomProperties)
+                {
+                    theNumberItemsToFetch = theNumberOfCustomProperties;
+                }
             }
-            
+
             if(theNumberItemsToFetch > 0)
             {
                 ((AudioServerPlugInCustomPropertyInfo*)outData)[0].mSelector = kAudioDeviceCustomPropertyAppVolumes;
@@ -936,6 +957,13 @@ void	BGM_Device::Device_GetPropertyData(AudioObjectID inObjectID, pid_t inClient
                 ((AudioServerPlugInCustomPropertyInfo*)outData)[6].mSelector = kAudioDeviceCustomPropertyDebugLoggingEnabled;
                 ((AudioServerPlugInCustomPropertyInfo*)outData)[6].mPropertyDataType = kAudioServerPlugInCustomPropertyDataTypeCFPropertyList;
                 ((AudioServerPlugInCustomPropertyInfo*)outData)[6].mQualifierDataType = kAudioServerPlugInCustomPropertyDataTypeNone;
+            }
+            // Index 7 is only reached for the main BGMDevice instance (see the clamp above).
+            if(theNumberItemsToFetch > 7)
+            {
+                ((AudioServerPlugInCustomPropertyInfo*)outData)[7].mSelector = kAudioDeviceCustomPropertyApplyingVolumeToAudio;
+                ((AudioServerPlugInCustomPropertyInfo*)outData)[7].mPropertyDataType = kAudioServerPlugInCustomPropertyDataTypeCFPropertyList;
+                ((AudioServerPlugInCustomPropertyInfo*)outData)[7].mQualifierDataType = kAudioServerPlugInCustomPropertyDataTypeNone;
             }
 
             outDataSize = theNumberItemsToFetch * sizeof(AudioServerPlugInCustomPropertyInfo);
@@ -981,6 +1009,14 @@ void	BGM_Device::Device_GetPropertyData(AudioObjectID inObjectID, pid_t inClient
         case kAudioDeviceCustomPropertyDebugLoggingEnabled:
             ThrowIf(inDataSize < sizeof(CFBooleanRef), CAException(kAudioHardwareBadPropertySizeError), "BGM_Device::Device_GetPropertyData: not enough space for the return value of kAudioDeviceCustomPropertyDebugLoggingEnabled for the device");
             *reinterpret_cast<CFBooleanRef*>(outData) = BGMDebugLoggingIsEnabled() ? kCFBooleanTrue : kCFBooleanFalse;
+            outDataSize = sizeof(CFBooleanRef);
+            break;
+
+        case kAudioDeviceCustomPropertyApplyingVolumeToAudio:
+            ThrowIf(inDataSize < sizeof(CFBooleanRef), CAException(kAudioHardwareBadPropertySizeError), "BGM_Device::Device_GetPropertyData: not enough space for the return value of kAudioDeviceCustomPropertyApplyingVolumeToAudio for the device");
+            // mWillApplyVolumeToAudio is atomic, so this is read without locking.
+            *reinterpret_cast<CFBooleanRef*>(outData) =
+                    mVolumeControl.WillApplyVolumeToAudioRT() ? kCFBooleanTrue : kCFBooleanFalse;
             outDataSize = sizeof(CFBooleanRef);
             break;
             
@@ -1285,6 +1321,56 @@ void	BGM_Device::Device_SetPropertyData(AudioObjectID inObjectID, pid_t inClient
             }
             break;
 
+        case kAudioDeviceCustomPropertyApplyingVolumeToAudio:
+            {
+                ThrowIf(inDataSize < sizeof(CFBooleanRef),
+                        CAException(kAudioHardwareBadPropertySizeError),
+                        "BGM_Device::Device_SetPropertyData: wrong size for the data for "
+                        "kAudioDeviceCustomPropertyApplyingVolumeToAudio");
+
+                CFBooleanRef theRef = *reinterpret_cast<const CFBooleanRef*>(inData);
+
+                ThrowIfNULL(theRef,
+                            CAException(kAudioHardwareIllegalOperationError),
+                            "BGM_Device::Device_SetPropertyData: null reference given for "
+                            "kAudioDeviceCustomPropertyApplyingVolumeToAudio");
+                ThrowIf(CFGetTypeID(theRef) != CFBooleanGetTypeID(),
+                        CAException(kAudioHardwareIllegalOperationError),
+                        "BGM_Device::Device_SetPropertyData: CFType given for "
+                        "kAudioDeviceCustomPropertyApplyingVolumeToAudio was not a CFBoolean");
+
+                // Only the main BGMDevice instance applies its volume to audio on request. The UI
+                // sounds instance always applies its own volume, so reject attempts to change it.
+                ThrowIf(GetObjectID() != kObjectID_Device,
+                        CAException(kAudioHardwareIllegalOperationError),
+                        "BGM_Device::Device_SetPropertyData: "
+                        "kAudioDeviceCustomPropertyApplyingVolumeToAudio is only supported on the "
+                        "main BGMDevice instance");
+
+                bool theNewValue = CFBooleanGetValue(theRef);
+                bool propertyWasChanged =
+                        (mVolumeControl.WillApplyVolumeToAudioRT() != theNewValue);
+
+                // mWillApplyVolumeToAudio is atomic and read on the IO thread without locking, so
+                // there's nothing to lock around here. WillDoIOOperation always reports that this
+                // device does the ProcessMix operation, so the change takes effect on the next IO
+                // cycle without the host having to rebuild its IO plan.
+                mVolumeControl.SetWillApplyVolumeToAudio(theNewValue);
+
+                DebugMsg("BGM_Device::Device_SetPropertyData: %s applying volume to audio in software",
+                         theNewValue ? "Started" : "Stopped");
+
+                if(propertyWasChanged)
+                {
+                    // Send notification
+                    CADispatchQueue::GetGlobalSerialQueue().Dispatch(false,	^{
+                        AudioObjectPropertyAddress theChangedProperties[] = { kBGMApplyingVolumeToAudioAddress };
+                        BGM_PlugIn::Host_PropertiesChanged(inObjectID, 1, theChangedProperties);
+                    });
+                }
+            }
+            break;
+
 		default:
 			BGM_AbstractDevice::SetPropertyData(inObjectID, inClientPID, inAddress, inQualifierDataSize, inQualifierData, inDataSize, inData);
 			break;
@@ -1417,7 +1503,11 @@ void	BGM_Device::WillDoIOOperation(UInt32 inOperationID, bool& outWillDo, bool& 
 			break;
 
         case kAudioServerPlugInIOOperationProcessMix:
-            outWillDo = mVolumeControl.WillApplyVolumeToAudioRT();
+            // Always claim this operation so mVolumeControl.SetWillApplyVolumeToAudio can be toggled
+            // at runtime (BGMApp does this when the output device changes) without the host having to
+            // rebuild its IO plan. ApplyVolumeToAudioRT is a no-op when the control isn't applying
+            // its volume, so this is cheap when software volume is off.
+            outWillDo = true;
             outWillDoInPlace = true;
             break;
 
@@ -1501,7 +1591,10 @@ void	BGM_Device::DoIOOperation(AudioObjectID inStreamObjectID, UInt32 inClientID
                 CAMutex::Locker theIOLocker(mIOMutex);
 
                 // We ask to do this IO operation so this device can apply its own volume to the
-                // stream. Currently, only the UI sounds device does.
+                // stream. The UI sounds instance always does this; the main instance does it when
+                // BGMApp has enabled software volume (i.e. when the output device has no hardware
+                // volume control). ApplyVolumeToAudioRT is a no-op when this control isn't applying
+                // its volume, so it's safe to call unconditionally here.
                 mVolumeControl.ApplyVolumeToAudioRT(reinterpret_cast<Float32*>(ioMainBuffer),
                                                     inIOBufferFrameSize);
             }

--- a/BGMDriver/BGMDriver/BGM_Device.cpp
+++ b/BGMDriver/BGMDriver/BGM_Device.cpp
@@ -1352,9 +1352,9 @@ void	BGM_Device::Device_SetPropertyData(AudioObjectID inObjectID, pid_t inClient
                         (mVolumeControl.WillApplyVolumeToAudioRT() != theNewValue);
 
                 // mWillApplyVolumeToAudio is atomic and read on the IO thread without locking, so
-                // there's nothing to lock around here. WillDoIOOperation always reports that this
-                // device does the ProcessMix operation, so the change takes effect on the next IO
-                // cycle without the host having to rebuild its IO plan.
+                // there's nothing to lock around here. The main instance applies its volume in the
+                // ProcessOutput operation, which reads this flag every cycle, so the change takes
+                // effect immediately without the host having to rebuild its IO plan.
                 mVolumeControl.SetWillApplyVolumeToAudio(theNewValue);
 
                 DebugMsg("BGM_Device::Device_SetPropertyData: %s applying volume to audio in software",
@@ -1503,11 +1503,15 @@ void	BGM_Device::WillDoIOOperation(UInt32 inOperationID, bool& outWillDo, bool& 
 			break;
 
         case kAudioServerPlugInIOOperationProcessMix:
-            // Always claim this operation so mVolumeControl.SetWillApplyVolumeToAudio can be toggled
-            // at runtime (BGMApp does this when the output device changes) without the host having to
-            // rebuild its IO plan. ApplyVolumeToAudioRT is a no-op when the control isn't applying
-            // its volume, so this is cheap when software volume is off.
-            outWillDo = true;
+            // Only the UI sounds instance applies its volume here. The main instance applies its
+            // software volume per-client in the ProcessOutput operation instead, so it never has to
+            // claim ProcessMix. If the main instance (which is the default output device) claimed
+            // ProcessMix, coreaudiod would keep its IO pipeline running every cycle. That keeps the
+            // input device active (so macOS shows the microphone as in use) and leaves
+            // kAudioDevicePropertyDeviceIsRunningSomewhere permanently true, which stops playthrough
+            // from restarting after it goes idle.
+            outWillDo = mVolumeControl.WillApplyVolumeToAudioRT() &&
+                        (GetObjectID() != kObjectID_Device);
             outWillDoInPlace = true;
             break;
 
@@ -1572,12 +1576,29 @@ void	BGM_Device::DoIOOperation(AudioObjectID inStreamObjectID, UInt32 inClientID
 												 reinterpret_cast<const Float32*>(ioMainBuffer));
             }
 
-            // Record that a non-BGMApp client is actively doing IO by updating the timestamp.
+            // Record that a non-BGMApp client is actively doing IO by updating the timestamp. This
+            // drives idle detection (see BGMPlayThrough::StopIfIdle in BGMApp).
 			// TODO: We probably don't need to call this for kAudioServerPlugInIOOperationProcessOutput (every client).
 			//       kAudioServerPlugInIOOperationProcessMix would be more efficient.
             mClients.RecordNonBGMAppIO(inClientID);
 
             ApplyClientRelativeVolume(inClientID, inIOBufferFrameSize, ioMainBuffer);
+
+            // The main BGMDevice instance applies its software output volume here, per client and
+            // before the mix, rather than in the ProcessMix operation. Applying the gain to each
+            // client's buffer is equivalent to applying it to the mixed buffer, and it means the main
+            // instance never has to claim ProcessMix. That matters because the main instance is the
+            // default output device: if it claimed ProcessMix, coreaudiod would keep its IO pipeline
+            // running every cycle, which keeps the input device active (macOS then shows the
+            // microphone as in use) and leaves kAudioDevicePropertyDeviceIsRunningSomewhere
+            // permanently true, so playthrough couldn't restart after going idle.
+            // ApplyVolumeToAudioRT is a no-op when this instance isn't applying its volume.
+            if(GetObjectID() == kObjectID_Device)
+            {
+                CAMutex::Locker theIOLocker(mIOMutex);
+                mVolumeControl.ApplyVolumeToAudioRT(reinterpret_cast<Float32*>(ioMainBuffer),
+                                                    inIOBufferFrameSize);
+            }
             break;
 
         case kAudioServerPlugInIOOperationProcessMix:
@@ -1590,11 +1611,10 @@ void	BGM_Device::DoIOOperation(AudioObjectID inStreamObjectID, UInt32 inClientID
 
                 CAMutex::Locker theIOLocker(mIOMutex);
 
-                // We ask to do this IO operation so this device can apply its own volume to the
-                // stream. The UI sounds instance always does this; the main instance does it when
-                // BGMApp has enabled software volume (i.e. when the output device has no hardware
-                // volume control). ApplyVolumeToAudioRT is a no-op when this control isn't applying
-                // its volume, so it's safe to call unconditionally here.
+                // Only the UI sounds instance performs this operation (see WillDoIOOperation). The
+                // main instance applies its software volume per-client in ProcessOutput instead, so
+                // it doesn't have to claim ProcessMix. ApplyVolumeToAudioRT is a no-op when this
+                // control isn't applying its volume.
                 mVolumeControl.ApplyVolumeToAudioRT(reinterpret_cast<Float32*>(ioMainBuffer),
                                                     inIOBufferFrameSize);
             }

--- a/BGMDriver/BGMDriver/BGM_VolumeControl.cpp
+++ b/BGMDriver/BGMDriver/BGM_VolumeControl.cpp
@@ -359,21 +359,27 @@ void    BGM_VolumeControl::SetVolumeDb(Float32 inNewVolumeDb)
 
 void    BGM_VolumeControl::SetWillApplyVolumeToAudio(bool inWillApplyVolumeToAudio)
 {
-    mWillApplyVolumeToAudio = inWillApplyVolumeToAudio;
+    // Atomic store. See the declaration of mWillApplyVolumeToAudio.
+    mWillApplyVolumeToAudio.store(inWillApplyVolumeToAudio, std::memory_order_relaxed);
 }
 
 #pragma mark IO Operations
 
 bool    BGM_VolumeControl::WillApplyVolumeToAudioRT() const
 {
-    return mWillApplyVolumeToAudio;
+    return mWillApplyVolumeToAudio.load(std::memory_order_relaxed);
 }
 
 void    BGM_VolumeControl::ApplyVolumeToAudioRT(Float32* ioBuffer, UInt32 inBufferFrameSize) const
 {
-    ThrowIf(!mWillApplyVolumeToAudio,
-            CAException(kAudioHardwareIllegalOperationError),
-            "BGM_VolumeControl::ApplyVolumeToAudioRT: This control doesn't process audio data");
+    // This control might not be applying its volume to the audio (e.g. the main BGMDevice instance
+    // only does so when the output device has no hardware volume control). In that case there's
+    // nothing to do. Reading the flag once here (rather than throwing) keeps this safe to call
+    // unconditionally on the IO thread even as the flag is toggled from another thread.
+    if(!mWillApplyVolumeToAudio.load(std::memory_order_relaxed))
+    {
+        return;
+    }
 
     // Don't bother if the change is very unlikely to be perceptible.
     if((mAmplitudeGain < 0.99f) || (mAmplitudeGain > 1.01f))

--- a/BGMDriver/BGMDriver/BGM_VolumeControl.h
+++ b/BGMDriver/BGMDriver/BGM_VolumeControl.h
@@ -30,6 +30,9 @@
 #include "CAVolumeCurve.h"
 #include "CAMutex.h"
 
+// STL Includes
+#include <atomic>
+
 
 #pragma clang assume_nonnull begin
 
@@ -111,6 +114,9 @@ public:
      Set this volume control to apply its volume to audio data, which allows clients to call
      ApplyVolumeToAudioRT. When this is set true, WillApplyVolumeToAudioRT will return true. Set to
      false initially.
+
+     This can be changed at runtime, including while IO is running (BGMApp toggles it when the output
+     device changes), so the backing flag is atomic and read on the IO thread without locking.
      */
     void                SetWillApplyVolumeToAudio(bool inWillApplyVolumeToAudio);
 
@@ -125,12 +131,13 @@ public:
      Apply this volume control's volume to the samples in ioBuffer. That is, increase/decrease the
      volumes of the samples by the current volume of this control.
 
+     Does nothing if this control isn't set to apply its volume to audio data (see
+     SetWillApplyVolumeToAudio), so it's safe to call unconditionally on the IO thread.
+
      @param ioBuffer The audio sample buffer to process.
      @param inBufferFrameSize The number of sample frames in ioBuffer. The audio is assumed to be in
                               stereo, i.e. two samples per frame. (Though, hopefully we'll support
                               more at some point.)
-     @throws CAException If SetWillApplyVolumeToAudio hasn't been used to set this control to apply
-                         its volume to audio data.
      */
     void                ApplyVolumeToAudioRT(Float32* ioBuffer, UInt32 inBufferFrameSize) const;
 
@@ -158,7 +165,9 @@ private:
     // volume of this control.
     Float32             mAmplitudeGain;
 
-    bool                mWillApplyVolumeToAudio;
+    // Whether this control applies its volume to the audio it processes (see ApplyVolumeToAudioRT).
+    // Atomic because it's read on the IO thread but can be set from other threads at runtime.
+    std::atomic<bool>   mWillApplyVolumeToAudio;
 
 };
 

--- a/SharedSource/BGM_Types.h
+++ b/SharedSource/BGM_Types.h
@@ -123,7 +123,14 @@ enum
     // by default. This property is settable. See the array indices below for more info.
     kAudioDeviceCustomPropertyEnabledOutputControls                   = 'bgct',
     // A CFBoolean. True if debug logging is enabled in BGMDriver. Settable.
-    kAudioDeviceCustomPropertyDebugLoggingEnabled                     = 'dblg'
+    kAudioDeviceCustomPropertyDebugLoggingEnabled                     = 'dblg',
+    // A CFBoolean. True if BGMDevice applies its (main output) volume to the audio it outputs, in
+    // software, rather than relying on BGMApp to mirror the volume onto the real output device's
+    // hardware volume control. BGMApp enables this when the selected output device has no hardware
+    // volume control (e.g. an HDMI monitor) so the volume slider/keys still work. Settable, false by
+    // default. Only meaningful for the main BGMDevice instance (not the UI sounds instance, which
+    // always applies its own volume).
+    kAudioDeviceCustomPropertyApplyingVolumeToAudio                   = 'apva'
 };
 
 // The number of silent/audible frames before BGMDriver will change kAudioDeviceCustomPropertyDeviceAudibleState
@@ -219,6 +226,12 @@ static const AudioObjectPropertyAddress kBGMEnabledOutputControlsAddress = {
 
 static const AudioObjectPropertyAddress kBGMDebugLoggingEnabledAddress = {
     kAudioDeviceCustomPropertyDebugLoggingEnabled,
+    kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyElementMain
+};
+
+static const AudioObjectPropertyAddress kBGMApplyingVolumeToAudioAddress = {
+    kAudioDeviceCustomPropertyApplyingVolumeToAudio,
     kAudioObjectPropertyScopeGlobal,
     kAudioObjectPropertyElementMain
 };


### PR DESCRIPTION
BGM mirrors its volume onto the output device's hardware volume control. For outputs with no settable hardware volume (e.g. HDMI/DisplayPort monitors), the slider was disabled and the volume was stuck at 100%.

This adds an automatic fallback: when the output has no hardware volume control, BGMDriver applies the volume to the audio **in software**, reusing `BGM_VolumeControl::ApplyVolumeToAudioRT` (already used by the UI-sounds device). A new driver custom property `kAudioDeviceCustomPropertyApplyingVolumeToAudio` ('apva') toggles the mode, decided in `BGMDeviceControlSync` so volume isn't attenuated twice. There's a Preferences toggle to disable it (on by default).

The second commit keeps playthrough able to go idle in this mode: the main device only claims the `ProcessMix` IO operation (and only counts client IO as active for audible buffers) when it's actually applying volume. Otherwise the default-output pipeline stayed active every cycle, which kept the input device — and the microphone-in-use indicator — on permanently.

### Testing
1. Use an output with no hardware volume control (e.g. an HDMI monitor).
2. The BGM volume slider now attenuates the audio sent to it.
3. Toggle the Preferences option off to restore the stock behavior.

### Known limitation
In software mode the driver applies gain rather than a hard mute, so the explicit Mute may not fully silence output; setting the slider to 0 does.
